### PR TITLE
Parser gamm

### DIFF
--- a/cmd/index.go
+++ b/cmd/index.go
@@ -35,7 +35,6 @@ var indexCmd = &cobra.Command{
 	or in the specified config file. Indexes taxable events into a database for easy querying. It is
 	highly recommended to keep this command running as a background service to keep your index up to date.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		//TODO: transition old main.go code to this subcommand
 		//TODO: split out setup methods and only call necessary ones
 		config, db, scheduler, err := setup(conf)
 		cobra.CheckErr(err)

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -14,7 +14,6 @@ var queryCmd = &cobra.Command{
 	your address to the command and a CSV export with your data for your address will be generated.`,
 	//If we want to pass errors up to the
 	Run: func(cmd *cobra.Command, args []string) {
-		//TODO: transition old rest API querying methods to this subcommand
 		//TODO: split out setup methods and only call necessary ones
 		_, db, _, err := setup(conf)
 		cobra.CheckErr(err)

--- a/osmosis/handlers.go
+++ b/osmosis/handlers.go
@@ -7,6 +7,7 @@ import (
 
 //Unmarshal JSON to a particular type.
 var MessageTypeHandler = map[string]func() txTypes.CosmosMessage{
-	"/osmosis.gamm.v1beta1.MsgSwapExactAmountIn":  func() txTypes.CosmosMessage { return &gamm.WrapperMsgSwapExactAmountIn{} },
-	"/osmosis.gamm.v1beta1.MsgSwapExactAmountOut": func() txTypes.CosmosMessage { return &gamm.WrapperMsgSwapExactAmountOut{} },
+	"/osmosis.gamm.v1beta1.MsgSwapExactAmountIn":      func() txTypes.CosmosMessage { return &gamm.WrapperMsgSwapExactAmountIn{} },
+	"/osmosis.gamm.v1beta1.MsgSwapExactAmountOut":     func() txTypes.CosmosMessage { return &gamm.WrapperMsgSwapExactAmountOut{} },
+	"/osmosis.gamm.v1beta1.MsgJoinSwapExternAmountIn": func() txTypes.CosmosMessage { return &gamm.WrapperMsgJoinSwapExternAmountIn{} },
 }

--- a/osmosis/handlers.go
+++ b/osmosis/handlers.go
@@ -11,4 +11,5 @@ var MessageTypeHandler = map[string]func() txTypes.CosmosMessage{
 	"/osmosis.gamm.v1beta1.MsgSwapExactAmountOut":     func() txTypes.CosmosMessage { return &gamm.WrapperMsgSwapExactAmountOut{} },
 	"/osmosis.gamm.v1beta1.MsgJoinSwapExternAmountIn": func() txTypes.CosmosMessage { return &gamm.WrapperMsgJoinSwapExternAmountIn{} },
 	"/osmosis.gamm.v1beta1.MsgJoinPool":               func() txTypes.CosmosMessage { return &gamm.WrapperMsgJoinPool{} },
+	"/osmosis.gamm.v1beta1.MsgExitPool":               func() txTypes.CosmosMessage { return &gamm.WrapperMsgExitPool{} },
 }

--- a/osmosis/handlers.go
+++ b/osmosis/handlers.go
@@ -10,4 +10,5 @@ var MessageTypeHandler = map[string]func() txTypes.CosmosMessage{
 	"/osmosis.gamm.v1beta1.MsgSwapExactAmountIn":      func() txTypes.CosmosMessage { return &gamm.WrapperMsgSwapExactAmountIn{} },
 	"/osmosis.gamm.v1beta1.MsgSwapExactAmountOut":     func() txTypes.CosmosMessage { return &gamm.WrapperMsgSwapExactAmountOut{} },
 	"/osmosis.gamm.v1beta1.MsgJoinSwapExternAmountIn": func() txTypes.CosmosMessage { return &gamm.WrapperMsgJoinSwapExternAmountIn{} },
+	"/osmosis.gamm.v1beta1.MsgJoinPool":               func() txTypes.CosmosMessage { return &gamm.WrapperMsgJoinPool{} },
 }


### PR DESCRIPTION
Adds support to the Osmosis GAMM module for the following message types:

- MsgJoinSwapExternAmountIn
- MsgJoinPool
- MsgExitPool

These transactions happen a lot in Osmosis, so they were the easiest to find and test against. Tested against the following blocks:

- MsgJoinSwapExternAmountIn - 5827922
- MsgJoinPool - 5827920
- MsgExitPool - 5827852
