### PR TITLE
Adds method for adding missing denoms to the denom tables

### DIFF
--- a/cmd/index.go
+++ b/cmd/index.go
@@ -300,7 +300,7 @@ func ProcessTxs(
 
 	for {
 		txToProcess := <-results
-		txDBWrappers, err := core.ProcessRpcTxs(txToProcess.CosmosGetTxsEventResponse)
+		txDBWrappers, err := core.ProcessRpcTxs(db, txToProcess.CosmosGetTxsEventResponse)
 		if err != nil {
 			config.Logger.Error("ProcessRpcTxs: unhandled error", zap.Error(err))
 			failedBlockHandler(txToProcess.Height, core.UnprocessableTxError, err)

--- a/db/db.go
+++ b/db/db.go
@@ -179,14 +179,13 @@ func IndexNewBlock(db *gorm.DB, blockHeight int64, txs []TxDBWrapper, chainID st
 }
 
 func UpsertDenoms(db *gorm.DB, denoms []DenomDBWrapper) error {
-
 	return db.Transaction(func(dbTransaction *gorm.DB) error {
 
 		for _, denom := range denoms {
 
 			if err := dbTransaction.Clauses(clause.OnConflict{
-				Columns:   []clause.Column{{Name: "name"}},
-				DoUpdates: clause.AssignmentColumns([]string{"symbol", "base"}),
+				Columns:   []clause.Column{{Name: "base"}},
+				DoUpdates: clause.AssignmentColumns([]string{"symbol", "name"}),
 			}).Create(&denom.Denom).Error; err != nil {
 				return err
 			}

--- a/db/models.go
+++ b/db/models.go
@@ -106,8 +106,8 @@ func (TaxableTransaction) TableName() string {
 
 type Denom struct {
 	ID     uint
-	Base   string
-	Name   string `gorm:"uniqueIndex"`
+	Base   string `gorm:"uniqueIndex"`
+	Name   string
 	Symbol string
 }
 


### PR DESCRIPTION
Also fix db arch bug that had a unique index on the denom name (prevented us from adding UNKNOWN for unknown denoms found during indexing). Switches unique index to the base (which is arguably the most unique item on denoms since names and symbols might not be unique).