### PR TITLE
Add first pass of tx grouping

### DIFF
--- a/cmd/query.go
+++ b/cmd/query.go
@@ -18,6 +18,8 @@ var queryCmd = &cobra.Command{
 		_, db, _, err := setup(conf)
 		cobra.CheckErr(err)
 
+		csv.BootstrapChainSpecificTxParsingGroups(conf.Lens.ChainID)
+
 		accountRows, err := csv.ParseForAddress(address, db)
 		cobra.CheckErr(err)
 

--- a/csv/osmosis.go
+++ b/csv/osmosis.go
@@ -20,8 +20,8 @@ type WrapperLpTxGroup struct {
 	GroupedTxes map[uint][]db.TaxableTransaction //TX db ID to its messages
 }
 
-func (sf WrapperLpTxGroup) BelongsToGroup(msgType string) bool {
-	_, isInGroup := IsOsmosisLpTxGroup[msgType]
+func (sf WrapperLpTxGroup) BelongsToGroup(message db.TaxableTransaction) bool {
+	_, isInGroup := IsOsmosisLpTxGroup[message.Message.MessageType]
 	return isInGroup
 }
 

--- a/csv/osmosis.go
+++ b/csv/osmosis.go
@@ -1,0 +1,71 @@
+package csv
+
+import (
+	"fmt"
+
+	"github.com/DefiantLabs/cosmos-tax-cli/db"
+)
+
+//Guard for adding messages to the group
+var IsOsmosisLpTxGroup = map[string]bool{
+	"/osmosis.gamm.v1beta1.MsgJoinSwapExternAmountIn":  true,
+	"/osmosis.gamm.v1beta1.MsgJoinSwapShareAmountOut":  true,
+	"/osmosis.gamm.v1beta1.MsgJoinPool":                true,
+	"/osmosis.gamm.v1beta1.MsgExitSwapShareAmountIn":   true,
+	"/osmosis.gamm.v1beta1.MsgExitSwapExternAmountOut": true,
+	"/osmosis.gamm.v1beta1.MsgExitPool":                true,
+}
+
+type WrapperLpTxGroup struct {
+	GroupedTxes map[uint][]db.TaxableTransaction //TX db ID to its messages
+}
+
+func (sf WrapperLpTxGroup) BelongsToGroup(msgType string) bool {
+	_, isInGroup := IsOsmosisLpTxGroup[msgType]
+	return isInGroup
+}
+
+func (sf WrapperLpTxGroup) String() string {
+	return "OsmosisLpTxGroup"
+}
+
+func (sf WrapperLpTxGroup) GetGroupedTxes() map[uint][]db.TaxableTransaction {
+	return sf.GroupedTxes
+}
+
+func (sf WrapperLpTxGroup) AddTxToGroup(tx db.TaxableTransaction) {
+	//Add tx to group using the TX ID as key and appending to array
+	if _, ok := sf.GroupedTxes[tx.Message.Tx.ID]; ok {
+		sf.GroupedTxes[tx.Message.Tx.ID] = append(sf.GroupedTxes[tx.Message.Tx.ID], tx)
+	} else {
+		var txGrouping []db.TaxableTransaction
+		txGrouping = append(txGrouping, tx)
+		sf.GroupedTxes[tx.Message.Tx.ID] = txGrouping
+	}
+}
+
+func (sf WrapperLpTxGroup) ParseGroup() ([]AccointingRow, error) {
+	var rows []AccointingRow
+
+	//TODO: Do specialized processing on LP messages
+	for i, txMessages := range sf.GroupedTxes {
+		fmt.Printf("TX with ID %d has %d message(s) in the parsing group\n", i, len(txMessages))
+		for _, message := range txMessages {
+			fmt.Println("Processing message", message.Message.MessageType)
+		}
+	}
+	return rows, nil
+}
+
+func GetOsmosisTxParsingGroups() []TxParsingGroup {
+	var messageGroups []TxParsingGroup
+
+	//This appending of parsing groups establishes a precedence
+	//There is a break statement in the loop doing grouping
+	//Which means parsers further up the array will be preferred
+	LpTxGroup := WrapperLpTxGroup{}
+	LpTxGroup.GroupedTxes = make(map[uint][]db.TaxableTransaction)
+	messageGroups = append(messageGroups, LpTxGroup)
+
+	return messageGroups
+}

--- a/csv/parser.go
+++ b/csv/parser.go
@@ -46,7 +46,7 @@ func (ac AccointingClassification) String() string {
 
 //Interface for all TX parsing groups
 type TxParsingGroup interface {
-	BelongsToGroup(string) bool
+	BelongsToGroup(db.TaxableTransaction) bool
 	String() string
 	AddTxToGroup(db.TaxableTransaction)
 	GetGroupedTxes() map[uint][]db.TaxableTransaction
@@ -220,7 +220,7 @@ func ParseTaxableTransactions(address string, pgSql *gorm.DB) ([]AccointingRow, 
 		for messageIndex, message := range tx {
 			for groupIndex, txGroup := range txParsingGroups {
 				//Store index of current message if it belongs in the group
-				if txGroup.BelongsToGroup(message.Message.MessageType) {
+				if txGroup.BelongsToGroup(message) {
 					if _, ok := groupsToMessageIds[groupIndex]; ok {
 						groupsToMessageIds[groupIndex] = append(groupsToMessageIds[groupIndex], messageIndex)
 					} else {


### PR DESCRIPTION
* Add an Interface for TxParsingGroup enforcing a standard, make an initial empty array (since we dont have any core parsing groups at the moment)
* Add a struct for the interface with Osmosis LP message types inclusion, bootstrap parser with this group using chain ID
* Pre-process address TX messages against every group bootstrapped in, remove messages that belong in a group
* Parse normal TXes after removal
* Push group parsing off to interface for the specific group