### PR TITLE
Osmosis exits joins parsing

### DIFF
--- a/csv/osmosis.go
+++ b/csv/osmosis.go
@@ -1,19 +1,32 @@
 package csv
 
 import (
-	"fmt"
-
 	"github.com/DefiantLabs/cosmos-tax-cli/db"
 )
 
-//Guard for adding messages to the group
-var IsOsmosisLpTxGroup = map[string]bool{
-	"/osmosis.gamm.v1beta1.MsgJoinSwapExternAmountIn":  true,
-	"/osmosis.gamm.v1beta1.MsgJoinSwapShareAmountOut":  true,
-	"/osmosis.gamm.v1beta1.MsgJoinPool":                true,
+var IsOsmosisJoin = map[string]bool{
+	"/osmosis.gamm.v1beta1.MsgJoinSwapExternAmountIn": true,
+	"/osmosis.gamm.v1beta1.MsgJoinSwapShareAmountOut": true,
+	"/osmosis.gamm.v1beta1.MsgJoinPool":               true,
+}
+
+var IsOsmosisExit = map[string]bool{
 	"/osmosis.gamm.v1beta1.MsgExitSwapShareAmountIn":   true,
 	"/osmosis.gamm.v1beta1.MsgExitSwapExternAmountOut": true,
 	"/osmosis.gamm.v1beta1.MsgExitPool":                true,
+}
+
+//Guard for adding messages to the group
+var IsOsmosisLpTxGroup = make(map[string]bool)
+
+func init() {
+	for messageType, _ := range IsOsmosisJoin {
+		IsOsmosisLpTxGroup[messageType] = true
+	}
+
+	for messageType, _ := range IsOsmosisExit {
+		IsOsmosisLpTxGroup[messageType] = true
+	}
 }
 
 type WrapperLpTxGroup struct {
@@ -48,10 +61,31 @@ func (sf WrapperLpTxGroup) ParseGroup() ([]AccointingRow, error) {
 	var rows []AccointingRow
 
 	//TODO: Do specialized processing on LP messages
-	for i, txMessages := range sf.GroupedTxes {
-		fmt.Printf("TX with ID %d has %d message(s) in the parsing group\n", i, len(txMessages))
+	for _, txMessages := range sf.GroupedTxes {
 		for _, message := range txMessages {
-			fmt.Println("Processing message", message.Message.MessageType)
+
+			row := AccointingRow{}
+			row.OperationId = message.Message.Tx.Hash
+			row.Date = FormatDatetime(message.Message.Tx.TimeStamp)
+			//We deliberately exclude the GAMM tokens from OutSell/InBuy for Exits/Joins respectively
+			//Accointing has no way of using the GAMM token to determine LP cost basis etc...
+			if _, ok := IsOsmosisExit[message.Message.MessageType]; ok {
+				denomRecieved := message.DenominationReceived
+				valueRecieved := message.AmountReceived
+				row.InBuyAmount = valueRecieved.String()
+				row.InBuyAsset = denomRecieved.Symbol
+				row.TransactionType = Withdraw
+				row.Classification = RemoveFunds
+				rows = append(rows, row)
+			} else if _, ok := IsOsmosisJoin[message.Message.MessageType]; ok {
+				denomSent := message.DenominationSent
+				valueSent := message.AmountSent
+				row.OutSellAmount = valueSent.String()
+				row.OutSellAsset = denomSent.Symbol
+				row.TransactionType = Deposit
+				row.Classification = LiquidityPool
+				rows = append(rows, row)
+			}
 		}
 	}
 	return rows, nil

--- a/csv/parser.go
+++ b/csv/parser.go
@@ -81,6 +81,7 @@ type AccointingRow struct {
 	Classification  AccointingClassification
 	TransactionType AccointingTransaction
 	OperationId     string
+	Comments        string
 }
 
 //ParseBasic: Handles the fields that are shared between most types.

--- a/csv/parser.go
+++ b/csv/parser.go
@@ -15,17 +15,18 @@ import (
 	"gorm.io/gorm"
 )
 
+//Accointing CSV Explainer found here, contains info on transaction types and classifications:
+//https://support.accointing.com/hc/en-us/articles/4423524486669-Uploading-data-via-the-ACCOINTING-com-CSV-XLSX-Template
 type AccointingTransaction int
 
 const (
 	Deposit AccointingTransaction = iota
 	Withdraw
 	Order
-	Swap
 )
 
 func (at AccointingTransaction) String() string {
-	return [...]string{"deposit", "withdraw", "order", "swap"}[at]
+	return [...]string{"deposit", "withdraw", "order"}[at]
 }
 
 type AccointingClassification int
@@ -36,12 +37,14 @@ const (
 	Airdrop
 	Payment
 	Fee
+	LiquidityPool
+	RemoveFunds //Used for GAMM module exits, is this correct?
 )
 
 func (ac AccointingClassification) String() string {
 	//Note that "None" returns empty string since we're using this for CSV parsing.
 	//Accointing considers 'Classification' an optional field, so empty is a valid value.
-	return [...]string{"", "staked", "airdrop", "payment", "fee"}[ac]
+	return [...]string{"", "staked", "airdrop", "payment", "fee", "liquidity_pool", "remove_funds"}[ac]
 }
 
 //Interface for all TX parsing groups
@@ -136,6 +139,7 @@ func (row *AccointingRow) ParseBasic(address string, event db.TaxableTransaction
 func (row *AccointingRow) ParseSwap(address string, event db.TaxableTransaction) error {
 	row.Date = FormatDatetime(event.Message.Tx.TimeStamp)
 	row.OperationId = event.Message.Tx.Hash
+	row.TransactionType = Order
 
 	recievedConversionAmount, recievedConversionSymbol, err := db.ConvertUnits(util.FromNumeric(event.AmountReceived), event.DenominationReceived)
 	if err == nil {
@@ -152,8 +156,6 @@ func (row *AccointingRow) ParseSwap(address string, event db.TaxableTransaction)
 	} else {
 		return fmt.Errorf("Cannot parse denom units for TX %s (classification: swap sent)\n", row.OperationId)
 	}
-
-	row.TransactionType = Swap
 
 	return nil
 }
@@ -237,10 +239,6 @@ func ParseTaxableTransactions(address string, pgSql *gorm.DB) ([]AccointingRow, 
 			}
 		}
 
-		if messagesToRemove != 0 {
-			fmt.Printf("Removing %d message(s) from TX with ID %d and adding to a parsing group\n", messagesToRemove, v)
-		}
-
 		//split off the messages into their respective group
 		for groupIndex, messageIndices := range groupsToMessageIds {
 			var currentGroup TxParsingGroup = txParsingGroups[groupIndex]
@@ -251,7 +249,6 @@ func ParseTaxableTransactions(address string, pgSql *gorm.DB) ([]AccointingRow, 
 				//Get message to remove at index - numElementsRemoved
 				var indexToRemove int = messageIndex - numElementsRemoved
 				var messageToRemove db.TaxableTransaction = tx[indexToRemove]
-				fmt.Printf("Removing message %s and adding to parsing group %s\n", messageToRemove.Message.MessageType, currentGroup)
 
 				//Add to group and remove from original TX
 				currentGroup.AddTxToGroup(messageToRemove)
@@ -264,10 +261,8 @@ func ParseTaxableTransactions(address string, pgSql *gorm.DB) ([]AccointingRow, 
 		}
 	}
 
-	fmt.Println()
-
 	//Parse all the potentially taxable events (one transaction group at a time)
-	for txDbId, txGroup := range txMap {
+	for _, txGroup := range txMap {
 		//All messages have been removed into a parsing group
 		if len(txGroup) != 0 {
 			//For the current transaction group, generate the rows for the CSV.
@@ -278,17 +273,11 @@ func ParseTaxableTransactions(address string, pgSql *gorm.DB) ([]AccointingRow, 
 			} else {
 				return nil, err
 			}
-		} else {
-			//TODO: Remove me, for demo purposes
-			fmt.Printf("TX ID %d has had all messages moved into a parsing group\n", txDbId)
 		}
 	}
 
-	fmt.Println()
-
 	//Parse all the txes found in the Parsing Groups
 	for _, txParsingGroup := range txParsingGroups {
-		fmt.Printf("Tx parsing group %s has %d tx to process\n", txParsingGroup, len(txParsingGroup.GetGroupedTxes()))
 
 		txRows, err := txParsingGroup.ParseGroup()
 		if err == nil {

--- a/csv/writer.go
+++ b/csv/writer.go
@@ -7,7 +7,7 @@ import (
 )
 
 var headers = []string{"transactionType", "date", "inBuyAmount", "inBuyAsset", "outSellAmount", "outSellAsset",
-	"feeAmount (optional)", "feeAsset (optional)", "classification (optional)", "operationId (optional)"}
+	"feeAmount (optional)", "feeAsset (optional)", "classification (optional)", "operationId (optional)", "comments (optional)"}
 
 //RowToCsv: Build a single row of data in the format expected by 'headers'
 func RowToCsv(row AccointingRow) []string {
@@ -48,6 +48,7 @@ func RowToCsv(row AccointingRow) []string {
 		row.FeeAsset,
 		row.Classification.String(),
 		row.OperationId,
+		"",
 	}
 }
 

--- a/db/denoms.go
+++ b/db/denoms.go
@@ -44,6 +44,16 @@ func GetDenomUnitForDenom(denom Denom) (DenomUnit, error) {
 	return DenomUnit{}, errors.New("GetDenomUnitForDenom: no denom unit for the specified denom")
 }
 
+func GetBaseDenomUnitForDenom(denom Denom) (DenomUnit, error) {
+	for _, denomUnit := range CachedDenomUnits {
+		if denomUnit.DenomID == denom.ID && denomUnit.Exponent == 0 {
+			return denomUnit, nil
+		}
+	}
+
+	return DenomUnit{}, errors.New("GetDenomUnitForDenom: no denom unit for the specified denom")
+}
+
 func GetHighestDenomUnit(denomUnit DenomUnit, denomUnits []DenomUnit) (DenomUnit, error) {
 	var highestDenomUnit DenomUnit = DenomUnit{Exponent: 0, Name: "not found for denom"}
 
@@ -66,7 +76,10 @@ func GetHighestDenomUnit(denomUnit DenomUnit, denomUnits []DenomUnit) (DenomUnit
 func ConvertUnits(amount *big.Int, denom Denom) (*big.Int, string, error) {
 
 	//Try denom unit first
-	denomUnit, err := GetDenomUnitForDenom(denom)
+	//We were originally just using GetDenomUnitForDenom, but since CachedDenoms is an array, it would sometimes
+	//return the non-Base denom unit (exponent != 0), which would break the power conversion process below i.e.
+	//it would sometimes do highestDenomUnit.Exponent = 6, denomUnit.Exponent = 6 -> pow = 0
+	denomUnit, err := GetBaseDenomUnitForDenom(denom)
 
 	if err != nil {
 		fmt.Println("Error getting denom unit for denom", denom)

--- a/db/denoms.go
+++ b/db/denoms.go
@@ -73,7 +73,7 @@ func GetHighestDenomUnit(denomUnit DenomUnit, denomUnits []DenomUnit) (DenomUnit
 }
 
 //TODO unit test this function
-func ConvertUnits(amount *big.Int, denom Denom) (*big.Int, string, error) {
+func ConvertUnits(amount *big.Int, denom Denom) (*big.Float, string, error) {
 
 	//Try denom unit first
 	//We were originally just using GetDenomUnitForDenom, but since CachedDenoms is an array, it would sometimes
@@ -95,11 +95,11 @@ func ConvertUnits(amount *big.Int, denom Denom) (*big.Int, string, error) {
 
 	symbol := denomUnit.Denom.Symbol
 
+	//We were converting the units to big.Int, which would cause a Token to appear 0 if the conversion resulted in an amount < 1
 	power := math.Pow(10, float64(highestDenomUnit.Exponent-denomUnit.Exponent))
-	pw := big.NewInt(int64(power))
-	convertedAmount := new(big.Int).Set(amount)
-	convertedAmount.Div(convertedAmount, pw)
-	return convertedAmount, symbol, nil
+	convertedAmount := new(big.Float).SetInt(amount)
+	dividedAmount := new(big.Float).Quo(convertedAmount, new(big.Float).SetFloat64(power))
+	return dividedAmount, symbol, nil
 }
 
 //This function assumes that the denom to be added is the base denom


### PR DESCRIPTION
After the last discussion, we decided that the ParsingGroup logic was a bit ahead of the curve since we will be treating Osmosis LP messages as basic sends and received. However, this PR keeps the parsing of Joins and Exits in the Osmosis LP parsing group. This makes it easier to parse only the relevant data (i.e. ignoring the GAMM token for now).

This PR also fixes a few bugs in the denom conversion, and makes the transition to outputting decimal values for the CSV amounts.