### PR TITLE
CSV Parser interface

### DIFF
--- a/cmd/query.go
+++ b/cmd/query.go
@@ -1,9 +1,11 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/DefiantLabs/cosmos-tax-cli/csv"
+	"github.com/DefiantLabs/cosmos-tax-cli/csv/parsers"
 	"github.com/spf13/cobra"
 )
 
@@ -14,6 +16,21 @@ var queryCmd = &cobra.Command{
 	your address to the command and a CSV export with your data for your address will be generated.`,
 	//If we want to pass errors up to the
 	Run: func(cmd *cobra.Command, args []string) {
+
+		found := false
+		parsers := parsers.GetParserKeys()
+		for _, v := range parsers {
+			if v == format {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			cmd.Help()
+			cobra.CheckErr(fmt.Sprintf("Invalid format %s, valid formats are %s", format, parsers))
+		}
+
 		//TODO: split out setup methods and only call necessary ones
 		_, db, _, err := setup(conf)
 		cobra.CheckErr(err)
@@ -33,12 +50,15 @@ var queryCmd = &cobra.Command{
 var (
 	address string //flag storage for the address to query on
 	output  string //flag storage for the output file location
+	format  string //flag storage for the output format
 )
 
 func init() {
 	queryCmd.Flags().StringVar(&address, "address", "", "The address to query for")
 	queryCmd.MarkFlagRequired("address")
 	queryCmd.Flags().StringVar(&output, "output", "./output.csv", "The output location")
+	queryCmd.Flags().StringVar(&format, "format", "accointing", "The format to output")
 
 	rootCmd.AddCommand(queryCmd)
+
 }

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -35,12 +35,10 @@ var queryCmd = &cobra.Command{
 		_, db, _, err := setup(conf)
 		cobra.CheckErr(err)
 
-		csv.BootstrapChainSpecificTxParsingGroups(conf.Lens.ChainID)
-
-		accountRows, err := csv.ParseForAddress(address, db)
+		csvRows, headers, err := csv.ParseForAddress(address, db, format, conf)
 		cobra.CheckErr(err)
 
-		buffer := csv.ToCsv(accountRows)
+		buffer := csv.ToCsv(csvRows, headers)
 
 		err = os.WriteFile(output, buffer.Bytes(), 0644)
 		cobra.CheckErr(err)
@@ -54,10 +52,17 @@ var (
 )
 
 func init() {
+	validFormats := parsers.GetParserKeys()
+
+	if len(validFormats) == 0 {
+		fmt.Println("Error during intialization, no CSV parsers found.")
+		os.Exit(1)
+	}
+
 	queryCmd.Flags().StringVar(&address, "address", "", "The address to query for")
 	queryCmd.MarkFlagRequired("address")
 	queryCmd.Flags().StringVar(&output, "output", "./output.csv", "The output location")
-	queryCmd.Flags().StringVar(&format, "format", "accointing", "The format to output")
+	queryCmd.Flags().StringVar(&format, "format", validFormats[0], "The format to output")
 
 	rootCmd.AddCommand(queryCmd)
 

--- a/csv/parser.go
+++ b/csv/parser.go
@@ -8,12 +8,18 @@ import (
 
 	"github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules/bank"
 	"github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules/staking"
+	"github.com/DefiantLabs/cosmos-tax-cli/csv/parsers"
+	"github.com/DefiantLabs/cosmos-tax-cli/csv/parsers/accointing"
 	"github.com/DefiantLabs/cosmos-tax-cli/db"
 	"github.com/DefiantLabs/cosmos-tax-cli/osmosis/modules/gamm"
 	"github.com/DefiantLabs/cosmos-tax-cli/util"
 
 	"gorm.io/gorm"
 )
+
+func init() {
+	parsers.AddParserToParsers(accointing.ParserKey, &accointing.AccointingParser{})
+}
 
 //Accointing CSV Explainer found here, contains info on transaction types and classifications:
 //https://support.accointing.com/hc/en-us/articles/4423524486669-Uploading-data-via-the-ACCOINTING-com-CSV-XLSX-Template

--- a/csv/parser.go
+++ b/csv/parser.go
@@ -1,466 +1,60 @@
 package csv
 
 import (
-	"errors"
 	"fmt"
 	"os"
-	"strconv"
 
-	"github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules/bank"
-	"github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules/staking"
+	"github.com/DefiantLabs/cosmos-tax-cli/config"
 	"github.com/DefiantLabs/cosmos-tax-cli/csv/parsers"
 	"github.com/DefiantLabs/cosmos-tax-cli/csv/parsers/accointing"
 	"github.com/DefiantLabs/cosmos-tax-cli/db"
-	"github.com/DefiantLabs/cosmos-tax-cli/osmosis/modules/gamm"
-	"github.com/DefiantLabs/cosmos-tax-cli/util"
 
 	"gorm.io/gorm"
 )
 
+//Theres got to be a better way to do this
 func init() {
-	parsers.AddParserToParsers(accointing.ParserKey, &accointing.AccointingParser{})
+	parsers.RegisterParser(accointing.ParserKey)
 }
 
-//Accointing CSV Explainer found here, contains info on transaction types and classifications:
-//https://support.accointing.com/hc/en-us/articles/4423524486669-Uploading-data-via-the-ACCOINTING-com-CSV-XLSX-Template
-type AccointingTransaction int
-
-const (
-	Deposit AccointingTransaction = iota
-	Withdraw
-	Order
-)
-
-func (at AccointingTransaction) String() string {
-	return [...]string{"deposit", "withdraw", "order"}[at]
-}
-
-type AccointingClassification int
-
-const (
-	None AccointingClassification = iota
-	Staked
-	Airdrop
-	Payment
-	Fee
-	LiquidityPool
-	RemoveFunds //Used for GAMM module exits, is this correct?
-)
-
-func (ac AccointingClassification) String() string {
-	//Note that "None" returns empty string since we're using this for CSV parsing.
-	//Accointing considers 'Classification' an optional field, so empty is a valid value.
-	return [...]string{"", "staked", "airdrop", "payment", "fee", "liquidity_pool", "remove_funds"}[ac]
-}
-
-//Interface for all TX parsing groups
-type TxParsingGroup interface {
-	BelongsToGroup(db.TaxableTransaction) bool
-	String() string
-	AddTxToGroup(db.TaxableTransaction)
-	GetGroupedTxes() map[uint][]db.TaxableTransaction
-	ParseGroup() ([]AccointingRow, error)
-}
-
-//Initial parsing groups is empty for now as we
-//dont currently have a use-case beyond the osmosis LP groups
-var txParsingGroups []TxParsingGroup
-
-func BootstrapChainSpecificTxParsingGroups(chainId string) {
-
-	switch chainId {
-	case "osmosis-1":
-		for _, v := range GetOsmosisTxParsingGroups() {
-			txParsingGroups = append(txParsingGroups, v)
-		}
+func GetParser(parserKey string) parsers.Parser {
+	if parserKey == "accointing" {
+		parser := accointing.AccointingParser{}
+		return &parser
 	}
-}
-
-type AccointingRow struct {
-	Date            string
-	InBuyAmount     string
-	InBuyAsset      string
-	OutSellAmount   string
-	OutSellAsset    string
-	FeeAmount       string
-	FeeAsset        string
-	Classification  AccointingClassification
-	TransactionType AccointingTransaction
-	OperationId     string
-	Comments        string
-}
-
-//ParseBasic: Handles the fields that are shared between most types.
-func (row *AccointingRow) EventParseBasic(address string, event db.TaxableEvent) error {
-	//row.Date = FormatDatetime(event.Message.Tx.TimeStamp) TODO, FML, I forgot to add a DB field for this. Ideally it should come from the block time.
-	//row.OperationId = ??? TODO - maybe use the block hash or something. This isn't a TX so there is no TX hash. Have to test Accointing response to using block hash.
-
-	//deposit
-	if event.EventAddress.Address == address {
-		conversionAmount, conversionSymbol, err := db.ConvertUnits(util.FromNumeric(event.Amount), event.Denomination)
-		if err == nil {
-			row.InBuyAmount = conversionAmount.String()
-			row.InBuyAsset = conversionSymbol
-		} else {
-			row.InBuyAmount = util.NumericToString(event.Amount)
-			row.InBuyAsset = event.Denomination.Base
-		}
-		row.TransactionType = Deposit
-		return nil
-	}
-
-	return errors.New("unknown TaxableEvent with ID " + strconv.FormatUint(uint64(event.ID), 10))
-}
-
-//ParseBasic: Handles the fields that are shared between most types.
-func (row *AccointingRow) ParseBasic(address string, event db.TaxableTransaction) error {
-	row.Date = FormatDatetime(event.Message.Tx.TimeStamp)
-	row.OperationId = event.Message.Tx.Hash
-
-	//deposit
-	if event.ReceiverAddress.Address == address {
-		conversionAmount, conversionSymbol, err := db.ConvertUnits(util.FromNumeric(event.AmountReceived), event.DenominationReceived)
-		if err == nil {
-			row.InBuyAmount = conversionAmount.String()
-			row.InBuyAsset = conversionSymbol
-		} else {
-			return fmt.Errorf("Cannot parse denom units for TX %s (classification: deposit)\n", row.OperationId)
-		}
-		row.TransactionType = Deposit
-
-	} else if event.SenderAddress.Address == address { //withdrawal
-
-		conversionAmount, conversionSymbol, err := db.ConvertUnits(util.FromNumeric(event.AmountSent), event.DenominationSent)
-		if err == nil {
-			row.OutSellAmount = conversionAmount.String()
-			row.OutSellAsset = conversionSymbol
-		} else {
-			return fmt.Errorf("Cannot parse denom units for TX %s (classification: withdrawal)\n", row.OperationId)
-		}
-		row.TransactionType = Withdraw
-	}
-
 	return nil
 }
 
-func (row *AccointingRow) ParseSwap(address string, event db.TaxableTransaction) error {
-	row.Date = FormatDatetime(event.Message.Tx.TimeStamp)
-	row.OperationId = event.Message.Tx.Hash
-	row.TransactionType = Order
+func ParseForAddress(address string, pgSql *gorm.DB, parserKey string, config config.Config) ([]parsers.CsvRow, []string, error) {
 
-	recievedConversionAmount, recievedConversionSymbol, err := db.ConvertUnits(util.FromNumeric(event.AmountReceived), event.DenominationReceived)
-	if err == nil {
-		row.InBuyAmount = recievedConversionAmount.String()
-		row.InBuyAsset = recievedConversionSymbol
-	} else {
-		return fmt.Errorf("Cannot parse denom units for TX %s (classification: swap received)\n", row.OperationId)
+	parser := GetParser(parserKey)
+	parser.InitializeParsingGroups(config)
+
+	taxableTxs, err := db.GetTaxableTransactions(address, pgSql)
+
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
 	}
 
-	sentConversionAmount, sentConversionSymbol, err := db.ConvertUnits(util.FromNumeric(event.AmountSent), event.DenominationSent)
-	if err == nil {
-		row.OutSellAmount = sentConversionAmount.String()
-		row.OutSellAsset = sentConversionSymbol
-	} else {
-		return fmt.Errorf("Cannot parse denom units for TX %s (classification: swap sent)\n", row.OperationId)
+	err = parser.ProcessTaxableTx(address, taxableTxs)
+
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
 	}
-
-	return nil
-}
-
-func ParseTaxableEvents(address string, pgSql *gorm.DB) ([]AccointingRow, error) {
-	rows := []AccointingRow{}
 
 	taxableEvents, err := db.GetTaxableEvents(address, pgSql)
+
 	if err != nil {
-		return nil, err
-	}
-
-	if len(taxableEvents) == 0 {
-		return rows, nil
-	}
-
-	//Parse all the potentially taxable events
-	for _, event := range taxableEvents {
-		//generate the rows for the CSV.
-		rows = append(rows, ParseEvent(address, event)...)
-	}
-
-	return rows, nil
-}
-
-func ParseTaxableTransactions(address string, pgSql *gorm.DB) ([]AccointingRow, error) {
-	taxableTxs, err := db.GetTaxableTransactions(address, pgSql)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(taxableTxs) == 0 {
-		return nil, errors.New("no events for the given address")
-	}
-
-	rows := []AccointingRow{}
-	txMap := map[uint][]db.TaxableTransaction{} //Map transaction ID to List of events
-
-	//Build a map so we know which TX go with which messages
-	for _, taxableTx := range taxableTxs {
-		if list, ok := txMap[taxableTx.Message.Tx.ID]; ok {
-			list = append(list, taxableTx)
-			txMap[taxableTx.Message.Tx.ID] = list
-		} else {
-			txMap[taxableTx.Message.Tx.ID] = []db.TaxableTransaction{taxableTx}
-		}
-	}
-
-	//TODO: Can probably reduce complexity
-	//The basic idea is we want to do the following:
-	//1. Loop through each message for each transaction
-	//2. Check if it belongs in a group by message type
-	//3. Gather indicies of all messages that belong in each group
-	//4. Remove them from the normal txMap
-	//5. Add them to the group-secific txMap
-	//The last two steps ensure that the message will not be parsed twice
-	for v, tx := range txMap {
-		//map: [group index] to []indexes of the current tx messages that belong in that group
-		var groupsToMessageIds map[int][]int = make(map[int][]int)
-
-		//TODO: Remove me, useless outside print for demo
-		messagesToRemove := 0
-
-		for messageIndex, message := range tx {
-			for groupIndex, txGroup := range txParsingGroups {
-				//Store index of current message if it belongs in the group
-				if txGroup.BelongsToGroup(message) {
-					if _, ok := groupsToMessageIds[groupIndex]; ok {
-						groupsToMessageIds[groupIndex] = append(groupsToMessageIds[groupIndex], messageIndex)
-					} else {
-						var messageArray []int
-						messageArray = append(messageArray, messageIndex)
-						groupsToMessageIds[groupIndex] = messageArray
-					}
-					messagesToRemove += 1
-
-					//Add it to the first group it belongs to and no others
-					//This establishes a precedence and prevents messages from being duplicated in many groups
-					break
-				}
-			}
-		}
-
-		//split off the messages into their respective group
-		for groupIndex, messageIndices := range groupsToMessageIds {
-			var currentGroup TxParsingGroup = txParsingGroups[groupIndex]
-
-			//used to keep the index relevant after splicing
-			numElementsRemoved := 0
-			for _, messageIndex := range messageIndices {
-				//Get message to remove at index - numElementsRemoved
-				var indexToRemove int = messageIndex - numElementsRemoved
-				var messageToRemove db.TaxableTransaction = tx[indexToRemove]
-
-				//Add to group and remove from original TX
-				currentGroup.AddTxToGroup(messageToRemove)
-				tx = append(tx[:indexToRemove], tx[indexToRemove+1:]...)
-				//overwrite the txMaps value at this tx to remove
-				txMap[v] = tx
-				numElementsRemoved = numElementsRemoved + 1
-			}
-
-		}
-	}
-
-	//Parse all the potentially taxable events (one transaction group at a time)
-	for _, txGroup := range txMap {
-		//All messages have been removed into a parsing group
-		if len(txGroup) != 0 {
-			//For the current transaction group, generate the rows for the CSV.
-			//Usually (but not always) a transaction will only have a single row in the CSV.
-			txRows, err := ParseTx(address, txGroup)
-			if err == nil {
-				rows = append(rows, txRows...)
-			} else {
-				return nil, err
-			}
-		}
-	}
-
-	//Parse all the txes found in the Parsing Groups
-	for _, txParsingGroup := range txParsingGroups {
-
-		txRows, err := txParsingGroup.ParseGroup()
-		if err == nil {
-			rows = append(rows, txRows...)
-		} else {
-			return nil, err
-		}
-	}
-
-	return rows, nil
-}
-
-func ParseForAddress(address string, pgSql *gorm.DB) ([]AccointingRow, error) {
-	allRows := []AccointingRow{}
-	rows, err := ParseTaxableTransactions(address, pgSql)
-	if err != nil {
-		//TODO
-		//We need to HANDLE the error in a way that notifies end users (of the website) that the CSV download failed.
-		//For now we just kill the program (that way I can't forget TODO this)
 		fmt.Println(err)
 		os.Exit(1)
 	}
 
-	allRows = append(allRows, rows...)
+	parser.ProcessTaxableEvent(address, taxableEvents)
 
-	//For now this gets all taxable events, which is only Osmosis rewards. Later we'll need to update the query to only grab Osmosis events.
-	//Reason being, presumably users will have an option to select or ignore certain chains.
-	rows, err = ParseTaxableEvents(address, pgSql)
-	if err != nil {
-		//TODO
-		//We need to HANDLE the error in a way that notifies end users (of the website) that the CSV download failed.
-		//For now we just kill the program (that way I can't forget TODO this)
-		fmt.Println(err)
-		os.Exit(1)
-	}
+	//Get rows once right at the end
+	rows := parser.GetRows()
 
-	allRows = append(allRows, rows...)
-	return allRows, err
-}
-
-//HandleFees:
-//If the transaction lists the same amount of fees as there are rows in the CSV,
-//then we spread the fees out one per row. Otherwise we add a line for the fees,
-//where each fee has a separate line.
-func HandleFees(address string, events []db.TaxableTransaction, rows []AccointingRow) ([]AccointingRow, error) {
-	//No events -- This address didn't pay any fees
-	if len(events) == 0 {
-		return rows, nil
-	}
-
-	fees := events[0].Message.Tx.Fees
-
-	for _, fee := range fees {
-		payer := fee.PayerAddress.Address
-		if payer != address {
-			return rows, nil
-		}
-	}
-
-	//Stick the fees in the existing rows.
-	if len(rows) >= len(fees) {
-		for i, fee := range fees {
-			conversionAmount, conversionSymbol, err := db.ConvertUnits(fee.Amount.BigInt(), fee.Denomination)
-			if err == nil {
-				rows[i].FeeAmount = conversionAmount.String()
-				rows[i].FeeAsset = conversionSymbol
-			} else {
-				return nil, fmt.Errorf("Cannot parse fee units for TX %s\n", events[0].Message.Tx.Hash)
-			}
-		}
-
-		return rows, nil
-	}
-
-	tx := events[0].Message.Tx
-	//There's more fees than rows so generate a new row for each fee.
-	for _, fee := range fees {
-		feeUnits, feeSymbol, err := db.ConvertUnits(fee.Amount.BigInt(), fee.Denomination)
-		if err != nil {
-			return nil, fmt.Errorf("Cannot parse fee units for TX %s\n", events[0].Message.Tx.Hash)
-		}
-
-		newRow := AccointingRow{Date: FormatDatetime(tx.TimeStamp), FeeAmount: feeUnits.String(),
-			FeeAsset: feeSymbol, Classification: Fee, TransactionType: Withdraw}
-		rows = append(rows, newRow)
-	}
-
-	return rows, nil
-}
-
-//ParseEvent: Parse the potentially taxable event
-func ParseEvent(address string, event db.TaxableEvent) []AccointingRow {
-	rows := []AccointingRow{}
-
-	if event.Source == db.OsmosisRewardDistribution {
-		row, err := ParseOsmosisReward(address, event)
-		if err == nil {
-			rows = append(rows, row)
-		} else {
-			//TODO: handle error parsing row. Should be impossible to reach this condition, ideally (once all bugs worked out)
-			os.Exit(1)
-		}
-	}
-
-	//rows = HandleFees(address, events, rows) TODO we have no fee handler for taxable EVENTS right now
-	return rows
-}
-
-//ParseTx: Parse the potentially taxable TX and Messages
-//This function is used for parsing a single TX that will not need to relate to any others
-//Use TX Parsing Groups to parse txes as a group
-func ParseTx(address string, events []db.TaxableTransaction) ([]AccointingRow, error) {
-	rows := []AccointingRow{}
-
-	for _, event := range events {
-		//Is this a MsgSend
-		if bank.IsMsgSend[event.Message.MessageType] {
-			rows = append(rows, ParseMsgSend(address, event))
-		} else if staking.IsMsgWithdrawValidatorCommission[event.Message.MessageType] {
-			rows = append(rows, ParseMsgWithdrawValidatorCommission(address, event))
-		} else if staking.IsMsgWithdrawDelegatorReward[event.Message.MessageType] {
-			rows = append(rows, ParseMsgWithdrawDelegatorReward(address, event))
-		} else if gamm.IsMsgSwapExactAmountIn[event.Message.MessageType] {
-			rows = append(rows, ParseMsgSwapExactAmountIn(address, event))
-		} else if gamm.IsMsgSwapExactAmountOut[event.Message.MessageType] {
-			rows = append(rows, ParseMsgSwapExactAmountOut(address, event))
-		} else {
-			fmt.Println("No parser for message type", event.Message.MessageType)
-		}
-	}
-
-	rows, err := HandleFees(address, events, rows)
-	return rows, err
-}
-
-//ParseMsgValidatorWithdraw:
-//This transaction is always a withdrawal.
-func ParseMsgWithdrawValidatorCommission(address string, event db.TaxableTransaction) AccointingRow {
-	row := &AccointingRow{}
-	row.ParseBasic(address, event)
-	row.Classification = Staked
-	return *row
-}
-
-//ParseMsgValidatorWithdraw:
-//This transaction is always a withdrawal.
-func ParseMsgWithdrawDelegatorReward(address string, event db.TaxableTransaction) AccointingRow {
-	row := &AccointingRow{}
-	row.ParseBasic(address, event)
-	row.Classification = Staked
-	return *row
-}
-
-//ParseMsgSend:
-//If the address we searched is the receiver, then this transaction is a deposit.
-//If the address we searched is the sender, then this transaction is a withdrawal.
-func ParseMsgSend(address string, event db.TaxableTransaction) AccointingRow {
-	row := &AccointingRow{}
-	row.ParseBasic(address, event)
-	return *row
-}
-
-func ParseMsgSwapExactAmountIn(address string, event db.TaxableTransaction) AccointingRow {
-	row := &AccointingRow{}
-	row.ParseSwap(address, event)
-	return *row
-}
-
-func ParseMsgSwapExactAmountOut(address string, event db.TaxableTransaction) AccointingRow {
-	row := &AccointingRow{}
-	row.ParseSwap(address, event)
-	return *row
-}
-
-func ParseOsmosisReward(address string, event db.TaxableEvent) (AccointingRow, error) {
-	row := &AccointingRow{}
-	err := row.EventParseBasic(address, event)
-	return *row, err
+	return rows, parser.GetHeaders(), nil
 }

--- a/csv/parsers/accointing/accointing.go
+++ b/csv/parsers/accointing/accointing.go
@@ -1,0 +1,43 @@
+package accointing
+
+import (
+	"github.com/DefiantLabs/cosmos-tax-cli/db"
+)
+
+var ParserKey string = "accointing"
+
+type AccointingParser struct {
+	Rows []AccointingRow
+}
+
+func (parser *AccointingParser) GetRowsFromTaxableTx(taxableTx []db.TaxableTransaction) [][]string {
+	var rows [][]string
+	for _, v := range parser.Rows {
+		newRow := v.GetRowForCsv()
+		rows = append(rows, newRow)
+	}
+
+	return rows
+}
+
+func (parser *AccointingParser) InitializeParsingGroups(chainId string) {
+
+}
+
+type AccointingRow struct {
+	Date            string
+	InBuyAmount     string
+	InBuyAsset      string
+	OutSellAmount   string
+	OutSellAsset    string
+	FeeAmount       string
+	FeeAsset        string
+	Classification  AccointingClassification
+	TransactionType AccointingTransaction
+	OperationId     string
+	Comments        string
+}
+
+func (row AccointingRow) GetRowForCsv() []string {
+	return nil
+}

--- a/csv/parsers/accointing/accointing.go
+++ b/csv/parsers/accointing/accointing.go
@@ -1,43 +1,295 @@
 package accointing
 
 import (
+	"fmt"
+	"os"
+
+	"github.com/DefiantLabs/cosmos-tax-cli/config"
+	"github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules/bank"
+	"github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules/staking"
+	"github.com/DefiantLabs/cosmos-tax-cli/csv/parsers"
 	"github.com/DefiantLabs/cosmos-tax-cli/db"
+	"github.com/DefiantLabs/cosmos-tax-cli/osmosis/modules/gamm"
 )
 
-var ParserKey string = "accointing"
+func (p *AccointingParser) ProcessTaxableTx(address string, taxableTxs []db.TaxableTransaction) error {
+	//process taxableTx into Rows above
+	txMap := map[uint][]db.TaxableTransaction{} //Map transaction ID to List of events
 
-type AccointingParser struct {
-	Rows []AccointingRow
+	//Build a map so we know which TX go with which messages
+	for _, taxableTx := range taxableTxs {
+		if list, ok := txMap[taxableTx.Message.Tx.ID]; ok {
+			list = append(list, taxableTx)
+			txMap[taxableTx.Message.Tx.ID] = list
+		} else {
+			txMap[taxableTx.Message.Tx.ID] = []db.TaxableTransaction{taxableTx}
+		}
+	}
+
+	//TODO: Can probably reduce complexity
+	//The basic idea is we want to do the following:
+	//1. Loop through each message for each transaction
+	//2. Check if it belongs in a group by message type
+	//3. Gather indicies of all messages that belong in each group
+	//4. Remove them from the normal txMap
+	//5. Add them to the group-secific txMap
+	//The last two steps ensure that the message will not be parsed twice
+	for v, tx := range txMap {
+		//map: [group index] to []indexes of the current tx messages that belong in that group
+		var groupsToMessageIds map[int][]int = make(map[int][]int)
+
+		//TODO: Remove me, useless outside print for demo
+		messagesToRemove := 0
+
+		for messageIndex, message := range tx {
+			for groupIndex, txGroup := range p.ParsingGroups {
+				//Store index of current message if it belongs in the group
+				if txGroup.BelongsToGroup(message) {
+					if _, ok := groupsToMessageIds[groupIndex]; ok {
+						groupsToMessageIds[groupIndex] = append(groupsToMessageIds[groupIndex], messageIndex)
+					} else {
+						var messageArray []int
+						messageArray = append(messageArray, messageIndex)
+						groupsToMessageIds[groupIndex] = messageArray
+					}
+					messagesToRemove += 1
+
+					//Add it to the first group it belongs to and no others
+					//This establishes a precedence and prevents messages from being duplicated in many groups
+					break
+				}
+			}
+		}
+
+		//split off the messages into their respective group
+		for groupIndex, messageIndices := range groupsToMessageIds {
+			var currentGroup parsers.ParsingGroup = p.ParsingGroups[groupIndex]
+
+			//used to keep the index relevant after splicing
+			numElementsRemoved := 0
+			for _, messageIndex := range messageIndices {
+				//Get message to remove at index - numElementsRemoved
+				var indexToRemove int = messageIndex - numElementsRemoved
+				var messageToRemove db.TaxableTransaction = tx[indexToRemove]
+
+				//Add to group and remove from original TX
+				currentGroup.AddTxToGroup(messageToRemove)
+				tx = append(tx[:indexToRemove], tx[indexToRemove+1:]...)
+				//overwrite the txMaps value at this tx to remove
+				txMap[v] = tx
+				numElementsRemoved = numElementsRemoved + 1
+			}
+
+		}
+	}
+
+	//Parse all the potentially taxable events (one transaction group at a time)
+	for _, txGroup := range txMap {
+		//All messages have been removed into a parsing group
+		if len(txGroup) != 0 {
+			//For the current transaction group, generate the rows for the CSV.
+			//Usually (but not always) a transaction will only have a single row in the CSV.
+			txRows, err := ParseTx(address, txGroup)
+			if err == nil {
+				for _, v := range txRows {
+					p.Rows = append(p.Rows, v.(AccointingRow))
+				}
+			} else {
+				return err
+			}
+		}
+	}
+
+	//Parse all the txes found in the Parsing Groups
+	for _, txParsingGroup := range p.ParsingGroups {
+		txParsingGroup.ParseGroup()
+	}
+
+	return nil
 }
 
-func (parser *AccointingParser) GetRowsFromTaxableTx(taxableTx []db.TaxableTransaction) [][]string {
-	var rows [][]string
-	for _, v := range parser.Rows {
-		newRow := v.GetRowForCsv()
-		rows = append(rows, newRow)
+func (p *AccointingParser) ProcessTaxableEvent(address string, taxableEvents []db.TaxableEvent) error {
+	//process taxableTx into Rows above
+
+	if len(taxableEvents) == 0 {
+		return nil
+	}
+
+	//Parse all the potentially taxable events
+	for _, event := range taxableEvents {
+		//generate the rows for the CSV.
+		p.Rows = append(p.Rows, ParseEvent(address, event)...)
+	}
+
+	return nil
+}
+
+func (p *AccointingParser) InitializeParsingGroups(config config.Config) {
+	switch config.Lens.ChainID {
+	case "osmosis-1":
+		for _, v := range GetOsmosisTxParsingGroups() {
+			p.ParsingGroups = append(p.ParsingGroups, v)
+		}
+	}
+}
+
+func (p *AccointingParser) GetRows() []parsers.CsvRow {
+	rows := make([]parsers.CsvRow, len(p.Rows))
+
+	for i, v := range p.Rows {
+		rows[i] = v
+	}
+
+	for _, v := range p.ParsingGroups {
+		for _, vv := range v.GetRowsForParsingGroup() {
+			rows = append(rows, vv)
+		}
 	}
 
 	return rows
 }
 
-func (parser *AccointingParser) InitializeParsingGroups(chainId string) {
-
+func (parser AccointingParser) GetHeaders() []string {
+	return []string{"transactionType", "date", "inBuyAmount", "inBuyAsset", "outSellAmount", "outSellAsset",
+		"feeAmount (optional)", "feeAsset (optional)", "classification (optional)", "operationId (optional)", "comments (optional)"}
 }
 
-type AccointingRow struct {
-	Date            string
-	InBuyAmount     string
-	InBuyAsset      string
-	OutSellAmount   string
-	OutSellAsset    string
-	FeeAmount       string
-	FeeAsset        string
-	Classification  AccointingClassification
-	TransactionType AccointingTransaction
-	OperationId     string
-	Comments        string
+//HandleFees:
+//If the transaction lists the same amount of fees as there are rows in the CSV,
+//then we spread the fees out one per row. Otherwise we add a line for the fees,
+//where each fee has a separate line.
+func HandleFees(address string, events []db.TaxableTransaction, rows []AccointingRow) ([]AccointingRow, error) {
+	//No events -- This address didn't pay any fees
+	if len(events) == 0 {
+		return rows, nil
+	}
+
+	fees := events[0].Message.Tx.Fees
+
+	for _, fee := range fees {
+		payer := fee.PayerAddress.Address
+		if payer != address {
+			return rows, nil
+		}
+	}
+
+	//Stick the fees in the existing rows.
+	if len(rows) >= len(fees) {
+		for i, fee := range fees {
+			conversionAmount, conversionSymbol, err := db.ConvertUnits(fee.Amount.BigInt(), fee.Denomination)
+			if err == nil {
+				rows[i].FeeAmount = conversionAmount.String()
+				rows[i].FeeAsset = conversionSymbol
+			} else {
+				return nil, fmt.Errorf("Cannot parse fee units for TX %s\n", events[0].Message.Tx.Hash)
+			}
+		}
+
+		return rows, nil
+	}
+
+	tx := events[0].Message.Tx
+	//There's more fees than rows so generate a new row for each fee.
+	for _, fee := range fees {
+		feeUnits, feeSymbol, err := db.ConvertUnits(fee.Amount.BigInt(), fee.Denomination)
+		if err != nil {
+			return nil, fmt.Errorf("Cannot parse fee units for TX %s\n", events[0].Message.Tx.Hash)
+		}
+
+		newRow := AccointingRow{Date: FormatDatetime(tx.TimeStamp), FeeAmount: feeUnits.String(),
+			FeeAsset: feeSymbol, Classification: Fee, TransactionType: Withdraw}
+		rows = append(rows, newRow)
+	}
+
+	return rows, nil
 }
 
-func (row AccointingRow) GetRowForCsv() []string {
-	return nil
+//ParseEvent: Parse the potentially taxable event
+func ParseEvent(address string, event db.TaxableEvent) []AccointingRow {
+	rows := []AccointingRow{}
+
+	if event.Source == db.OsmosisRewardDistribution {
+		row, err := ParseOsmosisReward(address, event)
+		if err == nil {
+			rows = append(rows, row)
+		} else {
+			//TODO: handle error parsing row. Should be impossible to reach this condition, ideally (once all bugs worked out)
+			os.Exit(1)
+		}
+	}
+
+	//rows = HandleFees(address, events, rows) TODO we have no fee handler for taxable EVENTS right now
+	return rows
+}
+
+//ParseTx: Parse the potentially taxable TX and Messages
+//This function is used for parsing a single TX that will not need to relate to any others
+//Use TX Parsing Groups to parse txes as a group
+func ParseTx(address string, events []db.TaxableTransaction) ([]parsers.CsvRow, error) {
+	rows := []parsers.CsvRow{}
+
+	for _, event := range events {
+		//Is this a MsgSend
+		if bank.IsMsgSend[event.Message.MessageType] {
+			rows = append(rows, ParseMsgSend(address, event))
+		} else if staking.IsMsgWithdrawValidatorCommission[event.Message.MessageType] {
+			rows = append(rows, ParseMsgWithdrawValidatorCommission(address, event))
+		} else if staking.IsMsgWithdrawDelegatorReward[event.Message.MessageType] {
+			rows = append(rows, ParseMsgWithdrawDelegatorReward(address, event))
+		} else if gamm.IsMsgSwapExactAmountIn[event.Message.MessageType] {
+			rows = append(rows, ParseMsgSwapExactAmountIn(address, event))
+		} else if gamm.IsMsgSwapExactAmountOut[event.Message.MessageType] {
+			rows = append(rows, ParseMsgSwapExactAmountOut(address, event))
+		} else {
+			fmt.Println("No parser for message type", event.Message.MessageType)
+		}
+	}
+
+	// rows, err := HandleFees(address, events, rows)
+	return rows, nil
+}
+
+//ParseMsgValidatorWithdraw:
+//This transaction is always a withdrawal.
+func ParseMsgWithdrawValidatorCommission(address string, event db.TaxableTransaction) AccointingRow {
+	row := &AccointingRow{}
+	row.ParseBasic(address, event)
+	row.Classification = Staked
+	return *row
+}
+
+//ParseMsgValidatorWithdraw:
+//This transaction is always a withdrawal.
+func ParseMsgWithdrawDelegatorReward(address string, event db.TaxableTransaction) AccointingRow {
+	row := &AccointingRow{}
+	row.ParseBasic(address, event)
+	row.Classification = Staked
+	return *row
+}
+
+//ParseMsgSend:
+//If the address we searched is the receiver, then this transaction is a deposit.
+//If the address we searched is the sender, then this transaction is a withdrawal.
+func ParseMsgSend(address string, event db.TaxableTransaction) AccointingRow {
+	row := &AccointingRow{}
+	row.ParseBasic(address, event)
+	return *row
+}
+
+func ParseMsgSwapExactAmountIn(address string, event db.TaxableTransaction) AccointingRow {
+	row := &AccointingRow{}
+	row.ParseSwap(address, event)
+	return *row
+}
+
+func ParseMsgSwapExactAmountOut(address string, event db.TaxableTransaction) AccointingRow {
+	row := &AccointingRow{}
+	row.ParseSwap(address, event)
+	return *row
+}
+
+func ParseOsmosisReward(address string, event db.TaxableEvent) (AccointingRow, error) {
+	row := &AccointingRow{}
+	err := row.EventParseBasic(address, event)
+	return *row, err
 }

--- a/csv/parsers/accointing/helpers.go
+++ b/csv/parsers/accointing/helpers.go
@@ -1,4 +1,4 @@
-package csv
+package accointing
 
 import (
 	"fmt"

--- a/csv/parsers/accointing/rows.go
+++ b/csv/parsers/accointing/rows.go
@@ -1,0 +1,104 @@
+package accointing
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/DefiantLabs/cosmos-tax-cli/db"
+	"github.com/DefiantLabs/cosmos-tax-cli/util"
+)
+
+func (row AccointingRow) GetRowForCsv() []string {
+
+	return []string{
+		row.TransactionType.String(),
+		row.Date,
+		row.InBuyAmount,
+		row.InBuyAsset,
+		row.OutSellAmount,
+		row.OutSellAsset,
+		row.FeeAmount,
+		row.FeeAsset,
+		row.Classification.String(),
+		row.OperationId,
+		"",
+	}
+}
+
+//ParseBasic: Handles the fields that are shared between most types.
+func (row *AccointingRow) EventParseBasic(address string, event db.TaxableEvent) error {
+	//row.Date = FormatDatetime(event.Message.Tx.TimeStamp) TODO, FML, I forgot to add a DB field for this. Ideally it should come from the block time.
+	//row.OperationId = ??? TODO - maybe use the block hash or something. This isn't a TX so there is no TX hash. Have to test Accointing response to using block hash.
+
+	//deposit
+	if event.EventAddress.Address == address {
+		conversionAmount, conversionSymbol, err := db.ConvertUnits(util.FromNumeric(event.Amount), event.Denomination)
+		if err == nil {
+			row.InBuyAmount = conversionAmount.String()
+			row.InBuyAsset = conversionSymbol
+		} else {
+			row.InBuyAmount = util.NumericToString(event.Amount)
+			row.InBuyAsset = event.Denomination.Base
+		}
+		row.TransactionType = Deposit
+		return nil
+	}
+
+	return errors.New("unknown TaxableEvent with ID " + strconv.FormatUint(uint64(event.ID), 10))
+}
+
+//ParseBasic: Handles the fields that are shared between most types.
+func (row *AccointingRow) ParseBasic(address string, event db.TaxableTransaction) error {
+	row.Date = FormatDatetime(event.Message.Tx.TimeStamp)
+	row.OperationId = event.Message.Tx.Hash
+
+	//deposit
+	if event.ReceiverAddress.Address == address {
+		conversionAmount, conversionSymbol, err := db.ConvertUnits(util.FromNumeric(event.AmountReceived), event.DenominationReceived)
+		if err == nil {
+			row.InBuyAmount = conversionAmount.String()
+			row.InBuyAsset = conversionSymbol
+		} else {
+			return fmt.Errorf("Cannot parse denom units for TX %s (classification: deposit)\n", row.OperationId)
+		}
+		row.TransactionType = Deposit
+
+	} else if event.SenderAddress.Address == address { //withdrawal
+
+		conversionAmount, conversionSymbol, err := db.ConvertUnits(util.FromNumeric(event.AmountSent), event.DenominationSent)
+		if err == nil {
+			row.OutSellAmount = conversionAmount.String()
+			row.OutSellAsset = conversionSymbol
+		} else {
+			return fmt.Errorf("Cannot parse denom units for TX %s (classification: withdrawal)\n", row.OperationId)
+		}
+		row.TransactionType = Withdraw
+	}
+
+	return nil
+}
+
+func (row *AccointingRow) ParseSwap(address string, event db.TaxableTransaction) error {
+	row.Date = FormatDatetime(event.Message.Tx.TimeStamp)
+	row.OperationId = event.Message.Tx.Hash
+	row.TransactionType = Order
+
+	recievedConversionAmount, recievedConversionSymbol, err := db.ConvertUnits(util.FromNumeric(event.AmountReceived), event.DenominationReceived)
+	if err == nil {
+		row.InBuyAmount = recievedConversionAmount.String()
+		row.InBuyAsset = recievedConversionSymbol
+	} else {
+		return fmt.Errorf("Cannot parse denom units for TX %s (classification: swap received)\n", row.OperationId)
+	}
+
+	sentConversionAmount, sentConversionSymbol, err := db.ConvertUnits(util.FromNumeric(event.AmountSent), event.DenominationSent)
+	if err == nil {
+		row.OutSellAmount = sentConversionAmount.String()
+		row.OutSellAsset = sentConversionSymbol
+	} else {
+		return fmt.Errorf("Cannot parse denom units for TX %s (classification: swap sent)\n", row.OperationId)
+	}
+
+	return nil
+}

--- a/csv/parsers/accointing/types.go
+++ b/csv/parsers/accointing/types.go
@@ -1,5 +1,28 @@
 package accointing
 
+import "github.com/DefiantLabs/cosmos-tax-cli/csv/parsers"
+
+var ParserKey string = "accointing"
+
+type AccointingParser struct {
+	Rows          []AccointingRow
+	ParsingGroups []parsers.ParsingGroup
+}
+
+type AccointingRow struct {
+	Date            string
+	InBuyAmount     string
+	InBuyAsset      string
+	OutSellAmount   string
+	OutSellAsset    string
+	FeeAmount       string
+	FeeAsset        string
+	Classification  AccointingClassification
+	TransactionType AccointingTransaction
+	OperationId     string
+	Comments        string
+}
+
 type AccointingTransaction int
 
 const (

--- a/csv/parsers/accointing/types.go
+++ b/csv/parsers/accointing/types.go
@@ -1,0 +1,31 @@
+package accointing
+
+type AccointingTransaction int
+
+const (
+	Deposit AccointingTransaction = iota
+	Withdraw
+	Order
+)
+
+func (at AccointingTransaction) String() string {
+	return [...]string{"deposit", "withdraw", "order"}[at]
+}
+
+type AccointingClassification int
+
+const (
+	None AccointingClassification = iota
+	Staked
+	Airdrop
+	Payment
+	Fee
+	LiquidityPool
+	RemoveFunds //Used for GAMM module exits, is this correct?
+)
+
+func (ac AccointingClassification) String() string {
+	//Note that "None" returns empty string since we're using this for CSV parsing.
+	//Accointing considers 'Classification' an optional field, so empty is a valid value.
+	return [...]string{"", "staked", "airdrop", "payment", "fee", "liquidity_pool", "remove_funds"}[ac]
+}

--- a/csv/parsers/parsers.go
+++ b/csv/parsers/parsers.go
@@ -1,0 +1,37 @@
+package parsers
+
+import "github.com/DefiantLabs/cosmos-tax-cli/db"
+
+type Parser interface {
+	GetRowsFromTaxableTx([]db.TaxableTransaction) [][]string
+	InitializeParsingGroups(chainId string)
+}
+
+var Parsers map[string]Parser
+
+//Check in your parsers here
+func init() {
+	Parsers = make(map[string]Parser)
+}
+
+func AddParserToParsers(key string, val Parser) {
+	Parsers[key] = val
+}
+
+func GetParserKeys() []string {
+	var parserKeys []string
+
+	for i, _ := range Parsers {
+		parserKeys = append(parserKeys, i)
+	}
+
+	return parserKeys
+}
+
+type TxParsingGroup interface {
+	BelongsToGroup(db.TaxableTransaction) bool
+	String() string
+	AddTxToGroup(db.TaxableTransaction)
+	GetGroupedTxes() map[uint][]db.TaxableTransaction
+	GetRowsForParsingGroup(string) [][]string
+}

--- a/csv/parsers/parsers.go
+++ b/csv/parsers/parsers.go
@@ -1,21 +1,14 @@
 package parsers
 
-import "github.com/DefiantLabs/cosmos-tax-cli/db"
-
-type Parser interface {
-	GetRowsFromTaxableTx([]db.TaxableTransaction) [][]string
-	InitializeParsingGroups(chainId string)
-}
-
-var Parsers map[string]Parser
-
 //Check in your parsers here
+var Parsers map[string]bool
+
 func init() {
-	Parsers = make(map[string]Parser)
+	Parsers = make(map[string]bool)
 }
 
-func AddParserToParsers(key string, val Parser) {
-	Parsers[key] = val
+func RegisterParser(key string) {
+	Parsers[key] = true
 }
 
 func GetParserKeys() []string {
@@ -26,12 +19,4 @@ func GetParserKeys() []string {
 	}
 
 	return parserKeys
-}
-
-type TxParsingGroup interface {
-	BelongsToGroup(db.TaxableTransaction) bool
-	String() string
-	AddTxToGroup(db.TaxableTransaction)
-	GetGroupedTxes() map[uint][]db.TaxableTransaction
-	GetRowsForParsingGroup(string) [][]string
 }

--- a/csv/parsers/types.go
+++ b/csv/parsers/types.go
@@ -1,13 +1,27 @@
 package parsers
 
-type Csv struct {
-	Rows []CsvRow
+import (
+	"github.com/DefiantLabs/cosmos-tax-cli/config"
+	"github.com/DefiantLabs/cosmos-tax-cli/db"
+)
+
+type Parser interface {
+	InitializeParsingGroups(config config.Config)
+	ProcessTaxableTx(address string, taxableTxs []db.TaxableTransaction) error
+	ProcessTaxableEvent(address string, taxableEvents []db.TaxableEvent) error
+	GetHeaders() []string
+	GetRows() []CsvRow
+}
+
+type ParsingGroup interface {
+	BelongsToGroup(db.TaxableTransaction) bool
+	String() string
+	AddTxToGroup(db.TaxableTransaction)
+	GetGroupedTxes() map[uint][]db.TaxableTransaction
+	ParseGroup() error
+	GetRowsForParsingGroup() []CsvRow
 }
 
 type CsvRow interface {
 	GetRowForCsv() []string
-}
-
-type CsvColumn interface {
-	String() string
 }

--- a/csv/parsers/types.go
+++ b/csv/parsers/types.go
@@ -1,0 +1,13 @@
+package parsers
+
+type Csv struct {
+	Rows []CsvRow
+}
+
+type CsvRow interface {
+	GetRowForCsv() []string
+}
+
+type CsvColumn interface {
+	String() string
+}

--- a/csv/writer.go
+++ b/csv/writer.go
@@ -4,56 +4,12 @@ import (
 	"bytes"
 	"encoding/csv"
 	"log"
+
+	"github.com/DefiantLabs/cosmos-tax-cli/csv/parsers"
 )
 
-var headers = []string{"transactionType", "date", "inBuyAmount", "inBuyAsset", "outSellAmount", "outSellAsset",
-	"feeAmount (optional)", "feeAsset (optional)", "classification (optional)", "operationId (optional)", "comments (optional)"}
-
-//RowToCsv: Build a single row of data in the format expected by 'headers'
-func RowToCsv(row AccointingRow) []string {
-
-	inAmt := row.InBuyAmount
-
-	//TODO: Somewhere in the last few months, row.InBuyAmount is getting turned into a string
-	//Is this really what we wanted to do?
-	// if row.InBuyAsset != "" {
-	// 	//inAmt = strconv.FormatFloat(row.InBuyAmount, 'E', -1, 64)
-	// 	inAmt = fmt.Sprintf("%s", row.InBuyAmount)
-	// }
-
-	outAmt := row.OutSellAmount
-	//TODO: Somewhere in the last few months, row.OutSellAmount is getting turned into a string
-	//Is this really what we wanted to do?
-	// if row.OutSellAsset != "" {
-	// 	//outAmt = strconv.FormatFloat(row.OutSellAmount, 'E', -1, 64)
-	// 	outAmt = fmt.Sprintf("%f", row.OutSellAmount)
-	// }
-
-	feeAmt := row.FeeAmount
-	//TODO: Somewhere in the last few months, row.FeeAmount is getting turned into a string
-	//Is this really what we wanted to do?
-	// if row.FeeAsset != "" {
-	// 	//feeAmt = strconv.FormatFloat(row.FeeAmount, 'E', -1, 64)
-	// 	feeAmt = fmt.Sprintf("%f", row.FeeAmount)
-	// }
-
-	return []string{
-		row.TransactionType.String(),
-		row.Date,
-		inAmt,
-		row.InBuyAsset,
-		outAmt,
-		row.OutSellAsset,
-		feeAmt,
-		row.FeeAsset,
-		row.Classification.String(),
-		row.OperationId,
-		"",
-	}
-}
-
 //Create the CSV and write it to byte buffer
-func ToCsv(rows []AccointingRow) bytes.Buffer {
+func ToCsv(rows []parsers.CsvRow, headers []string) bytes.Buffer {
 	var b bytes.Buffer
 	w := csv.NewWriter(&b)
 
@@ -63,7 +19,7 @@ func ToCsv(rows []AccointingRow) bytes.Buffer {
 
 	//write the accointing rows to the csv
 	for _, row := range rows {
-		csvForRow := RowToCsv(row)
+		csvForRow := row.GetRowForCsv()
 		if err := w.Write(csvForRow); err != nil {
 			log.Fatalln("error writing record to csv:", err)
 		}


### PR DESCRIPTION
Creates an interface for CSV parsers in the `csv/parsers` package:
* Add generic interfaces for parsing functionality to process and return expected types
* Move all accointing CSV logic into the `csv/parsers/accointing` subfolder and have it respect the interface definition
* Configure parser based on passed in format CLI argument
* Initialize parser, pre-process transactions into groups if needed, translate DB items to csv rows using the interface