### PR TITLE
Add support for MsgFundCommunity pool as a send

### DIFF
--- a/core/tx.go
+++ b/core/tx.go
@@ -8,6 +8,7 @@ import (
 	"github.com/DefiantLabs/cosmos-tax-cli/config"
 	parsingTypes "github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules"
 	"github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules/bank"
+	"github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules/distribution"
 	"github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules/staking"
 	tx "github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules/tx"
 	txTypes "github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules/tx"
@@ -34,6 +35,7 @@ var messageTypeHandler = map[string]func() txTypes.CosmosMessage{
 	"/cosmos.bank.v1beta1.MsgMultiSend":                           func() txTypes.CosmosMessage { return &bank.WrapperMsgMultiSend{} },
 	"/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward":     func() txTypes.CosmosMessage { return &staking.WrapperMsgWithdrawDelegatorReward{} },
 	"/cosmos.distribution.v1beta1.MsgWithdrawValidatorCommission": func() txTypes.CosmosMessage { return &staking.WrapperMsgWithdrawValidatorCommission{} },
+	"/cosmos.distribution.v1beta1.MsgFundCommunityPool":           func() txTypes.CosmosMessage { return &distribution.WrapperMsgFundCommunityPool{} },
 }
 
 //Merge the chain specific message type handlers into the core message type handler map

--- a/cosmos/modules/distribution/types.go
+++ b/cosmos/modules/distribution/types.go
@@ -1,0 +1,61 @@
+package distribution
+
+import (
+	"fmt"
+
+	txModule "github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules/tx"
+
+	parsingTypes "github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules"
+
+	stdTypes "github.com/cosmos/cosmos-sdk/types"
+	distTypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+)
+
+var IsMsgFundCommunityPool = map[string]bool{
+	"/cosmos.distribution.v1beta1.MsgFundCommunityPool": true,
+}
+
+type WrapperMsgFundCommunityPool struct {
+	txModule.Message
+	CosmosMsgFundCommunityPool *distTypes.MsgFundCommunityPool
+	Depositor                  string
+	Funds                      stdTypes.Coins
+}
+
+func (sf *WrapperMsgFundCommunityPool) String() string {
+	coinsReceivedString := sf.CosmosMsgFundCommunityPool.Amount.String()
+	depositorAddress := sf.CosmosMsgFundCommunityPool.Depositor
+
+	return fmt.Sprintf("MsgFundCommunityPool: Depositor %s gave %s\n",
+		depositorAddress, coinsReceivedString)
+}
+
+//HandleMsg: Handle type checking for MsgFundCommunityPool
+func (sf *WrapperMsgFundCommunityPool) HandleMsg(msgType string, msg stdTypes.Msg, log *txModule.TxLogMessage) error {
+	sf.Type = msgType
+	sf.CosmosMsgFundCommunityPool = msg.(*distTypes.MsgFundCommunityPool)
+
+	//Confirm that the action listed in the message log matches the Message type
+	valid_log := txModule.IsMessageActionEquals(sf.GetType(), log)
+	if !valid_log {
+		return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
+	}
+
+	//Funds sent and sender address are pulled from the parsed Cosmos Msg
+	sf.Depositor = sf.CosmosMsgFundCommunityPool.Depositor
+	sf.Funds = sf.CosmosMsgFundCommunityPool.Amount
+
+	return nil
+}
+
+func (sf *WrapperMsgFundCommunityPool) ParseRelevantData() []parsingTypes.MessageRelevantInformation {
+	var relevantData []parsingTypes.MessageRelevantInformation = make([]parsingTypes.MessageRelevantInformation, len(sf.Funds))
+
+	for i, v := range sf.Funds {
+		relevantData[i].AmountSent = v.Amount.BigInt()
+		relevantData[i].DenominationSent = v.Denom
+		relevantData[i].SenderAddress = sf.Depositor
+	}
+
+	return relevantData
+}

--- a/csv/parsers/accointing/accointing.go
+++ b/csv/parsers/accointing/accointing.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/DefiantLabs/cosmos-tax-cli/config"
 	"github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules/bank"
+	"github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules/distribution"
 	"github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules/staking"
 	"github.com/DefiantLabs/cosmos-tax-cli/csv/parsers"
 	"github.com/DefiantLabs/cosmos-tax-cli/db"
@@ -258,6 +259,8 @@ func ParseTx(address string, events []db.TaxableTransaction) ([]parsers.CsvRow, 
 			rows = append(rows, ParseMsgSend(address, event))
 		} else if bank.IsMsgMultiSend[event.Message.MessageType] {
 			rows = append(rows, ParseMsgMultiSend(address, event))
+		} else if distribution.IsMsgFundCommunityPool[event.Message.MessageType] {
+			rows = append(rows, ParseMsgFundCommunityPool(address, event))
 		} else if staking.IsMsgWithdrawValidatorCommission[event.Message.MessageType] {
 			rows = append(rows, ParseMsgWithdrawValidatorCommission(address, event))
 		} else if staking.IsMsgWithdrawDelegatorReward[event.Message.MessageType] {
@@ -302,6 +305,12 @@ func ParseMsgSend(address string, event db.TaxableTransaction) AccointingRow {
 }
 
 func ParseMsgMultiSend(address string, event db.TaxableTransaction) AccointingRow {
+	row := &AccointingRow{}
+	row.ParseBasic(address, event)
+	return *row
+}
+
+func ParseMsgFundCommunityPool(address string, event db.TaxableTransaction) AccointingRow {
 	row := &AccointingRow{}
 	row.ParseBasic(address, event)
 	return *row


### PR DESCRIPTION
Indexer support under cosmos/modules/distribution.

Query support under accointing CSV.

Tested on Osmosis block 5502435, tx hash 2E8C61F47FDD665B304BF6A0ACC12EAD39E40E8B817842853B8AE0516AB4AC73