### PR TITLE
Indexer and CSV accointing parser for MsgDelegate

### DIFF
--- a/core/tx.go
+++ b/core/tx.go
@@ -9,6 +9,7 @@ import (
 	parsingTypes "github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules"
 	"github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules/bank"
 	"github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules/distribution"
+	"github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules/staking"
 	tx "github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules/tx"
 	txTypes "github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules/tx"
 	"github.com/DefiantLabs/cosmos-tax-cli/db"
@@ -35,6 +36,7 @@ var messageTypeHandler = map[string]func() txTypes.CosmosMessage{
 	"/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward":     func() txTypes.CosmosMessage { return &distribution.WrapperMsgWithdrawDelegatorReward{} },
 	"/cosmos.distribution.v1beta1.MsgWithdrawValidatorCommission": func() txTypes.CosmosMessage { return &distribution.WrapperMsgWithdrawValidatorCommission{} },
 	"/cosmos.distribution.v1beta1.MsgFundCommunityPool":           func() txTypes.CosmosMessage { return &distribution.WrapperMsgFundCommunityPool{} },
+	"/cosmos.staking.v1beta1.MsgDelegate":                         func() txTypes.CosmosMessage { return &staking.WrapperMsgDelegate{} },
 }
 
 //Merge the chain specific message type handlers into the core message type handler map

--- a/cosmos/modules/staking/types.go
+++ b/cosmos/modules/staking/types.go
@@ -1,1 +1,72 @@
 package staking
+
+import (
+	"fmt"
+
+	txModule "github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules/tx"
+
+	parsingTypes "github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules"
+	stdTypes "github.com/cosmos/cosmos-sdk/types"
+	bankTypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	stakeTypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+)
+
+var IsMsgDelegate = map[string]bool{
+	"/cosmos.staking.v1beta1.MsgDelegate": true,
+}
+
+type WrapperMsgDelegate struct {
+	txModule.Message
+	CosmosMsgDelegate    *stakeTypes.MsgDelegate
+	DelegatorAddress     string
+	AutoWithdrawalReward *stdTypes.Coin
+}
+
+//HandleMsg: Handle type checking for MsgFundCommunityPool
+func (sf *WrapperMsgDelegate) HandleMsg(msgType string, msg stdTypes.Msg, log *txModule.TxLogMessage) error {
+	sf.Type = msgType
+	sf.CosmosMsgDelegate = msg.(*stakeTypes.MsgDelegate)
+
+	//Confirm that the action listed in the message log matches the Message type
+	valid_log := txModule.IsMessageActionEquals(sf.GetType(), log)
+	if !valid_log {
+		return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
+	}
+
+	//The attribute in the log message that shows you the delegator rewards auto-received
+	delegatorReceivedCoinsEvt := txModule.GetEventWithType(bankTypes.EventTypeTransfer, log)
+	if delegatorReceivedCoinsEvt == nil {
+		sf.AutoWithdrawalReward = nil
+		sf.DelegatorAddress = sf.CosmosMsgDelegate.DelegatorAddress
+	} else {
+		coins_received := txModule.GetValueForAttribute("amount", delegatorReceivedCoinsEvt)
+		coin, err := stdTypes.ParseCoinNormalized(coins_received)
+		if err == nil {
+			sf.AutoWithdrawalReward = &coin
+		} else {
+			return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
+		}
+		sf.DelegatorAddress = txModule.GetValueForAttribute("recipient", delegatorReceivedCoinsEvt)
+	}
+
+	return nil
+}
+
+func (sf *WrapperMsgDelegate) ParseRelevantData() []parsingTypes.MessageRelevantInformation {
+	var relevantData []parsingTypes.MessageRelevantInformation
+	if sf.AutoWithdrawalReward != nil {
+		data := parsingTypes.MessageRelevantInformation{}
+		data.AmountReceived = sf.AutoWithdrawalReward.Amount.BigInt()
+		data.DenominationReceived = sf.AutoWithdrawalReward.Denom
+		data.ReceiverAddress = sf.DelegatorAddress
+		relevantData = append(relevantData, data)
+	}
+	return relevantData
+}
+
+func (sf *WrapperMsgDelegate) String() string {
+	if sf.AutoWithdrawalReward == nil {
+		return fmt.Sprintf("MsgDelegate: Delegator %s did not auto-withdrawal rewards\n", sf.DelegatorAddress)
+	}
+	return fmt.Sprintf("MsgDelegate: Delegator %s auto-withdrew %s\n", sf.DelegatorAddress, sf.AutoWithdrawalReward)
+}

--- a/csv/parsers/accointing/accointing.go
+++ b/csv/parsers/accointing/accointing.go
@@ -8,6 +8,7 @@ import (
 	"github.com/DefiantLabs/cosmos-tax-cli/config"
 	"github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules/bank"
 	"github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules/distribution"
+	"github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules/staking"
 	"github.com/DefiantLabs/cosmos-tax-cli/csv/parsers"
 	"github.com/DefiantLabs/cosmos-tax-cli/db"
 	"github.com/DefiantLabs/cosmos-tax-cli/osmosis/modules/gamm"
@@ -263,6 +264,8 @@ func ParseTx(address string, events []db.TaxableTransaction) ([]parsers.CsvRow, 
 		} else if distribution.IsMsgWithdrawValidatorCommission[event.Message.MessageType] {
 			rows = append(rows, ParseMsgWithdrawValidatorCommission(address, event))
 		} else if distribution.IsMsgWithdrawDelegatorReward[event.Message.MessageType] {
+			rows = append(rows, ParseMsgWithdrawDelegatorReward(address, event))
+		} else if staking.IsMsgDelegate[event.Message.MessageType] {
 			rows = append(rows, ParseMsgWithdrawDelegatorReward(address, event))
 		} else if gamm.IsMsgSwapExactAmountIn[event.Message.MessageType] {
 			rows = append(rows, ParseMsgSwapExactAmountIn(address, event))


### PR DESCRIPTION
Only indexes data when the auto-reward withdrawal transfer event is populated.

Tested on block `6273449`, tx `AFC9F92E83D20615E6398FAD380D2E6BE83082AD50DAC154D4D58534F62A64B2`:
* Contains a number of messages with auto-reward withdrawal delegations
* Creates received events when transfer event is found, sets received address to recipient address

Tested on block `6275885`, tx `DFF77C707A38F201BE09F0C20A3636359CECECECBA976C6112A25302689F11FC`:
* Contains a message where a delegation did not auto-withdraw rewards
* Creates no events at all, returns an empty relevant data array

CSV accointing parser uses the normal ParseBasic function to create a InBuyAmount etc...