### PR TITLE
Indexer and CSV accointing parser for MsgUndelegate

### DIFF
--- a/core/tx.go
+++ b/core/tx.go
@@ -37,6 +37,7 @@ var messageTypeHandler = map[string]func() txTypes.CosmosMessage{
 	"/cosmos.distribution.v1beta1.MsgWithdrawValidatorCommission": func() txTypes.CosmosMessage { return &distribution.WrapperMsgWithdrawValidatorCommission{} },
 	"/cosmos.distribution.v1beta1.MsgFundCommunityPool":           func() txTypes.CosmosMessage { return &distribution.WrapperMsgFundCommunityPool{} },
 	"/cosmos.staking.v1beta1.MsgDelegate":                         func() txTypes.CosmosMessage { return &staking.WrapperMsgDelegate{} },
+	"/cosmos.staking.v1beta1.MsgUndelegate":                       func() txTypes.CosmosMessage { return &staking.WrapperMsgUndelegate{} },
 }
 
 //Merge the chain specific message type handlers into the core message type handler map

--- a/cosmos/modules/staking/types.go
+++ b/cosmos/modules/staking/types.go
@@ -15,9 +15,20 @@ var IsMsgDelegate = map[string]bool{
 	"/cosmos.staking.v1beta1.MsgDelegate": true,
 }
 
+var IsMsgUndelegate = map[string]bool{
+	"/cosmos.staking.v1beta1.MsgUndelegate": true,
+}
+
 type WrapperMsgDelegate struct {
 	txModule.Message
 	CosmosMsgDelegate    *stakeTypes.MsgDelegate
+	DelegatorAddress     string
+	AutoWithdrawalReward *stdTypes.Coin
+}
+
+type WrapperMsgUndelegate struct {
+	txModule.Message
+	CosmosMsgUndelegate  *stakeTypes.MsgUndelegate
 	DelegatorAddress     string
 	AutoWithdrawalReward *stdTypes.Coin
 }
@@ -52,7 +63,64 @@ func (sf *WrapperMsgDelegate) HandleMsg(msgType string, msg stdTypes.Msg, log *t
 	return nil
 }
 
+func (sf *WrapperMsgUndelegate) HandleMsg(msgType string, msg stdTypes.Msg, log *txModule.TxLogMessage) error {
+	sf.Type = msgType
+	sf.CosmosMsgUndelegate = msg.(*stakeTypes.MsgUndelegate)
+
+	//Confirm that the action listed in the message log matches the Message type
+	valid_log := txModule.IsMessageActionEquals(sf.GetType(), log)
+	if !valid_log {
+		return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
+	}
+
+	//The attribute in the log message that shows you the delegator rewards auto-received
+	sf.DelegatorAddress = sf.CosmosMsgUndelegate.DelegatorAddress
+	delegatorReceivedCoinsEvt := txModule.GetEventWithType(bankTypes.EventTypeCoinReceived, log)
+	if delegatorReceivedCoinsEvt == nil {
+		sf.AutoWithdrawalReward = nil
+		sf.DelegatorAddress = sf.CosmosMsgUndelegate.DelegatorAddress
+	} else {
+		var receivers []string
+		var amounts []string
+
+		//Pair off amounts and receivers in order
+		for _, v := range delegatorReceivedCoinsEvt.Attributes {
+			if v.Key == "receiver" {
+				receivers = append(receivers, v.Value)
+			} else if v.Key == "amount" {
+				amounts = append(amounts, v.Value)
+			}
+		}
+
+		//Find delegator address in receivers if its there, find its paired amount and set as the withdrawn rewards
+		for i, v := range receivers {
+			if v == sf.DelegatorAddress {
+				coin, err := stdTypes.ParseCoinNormalized(amounts[i])
+				if err == nil {
+					sf.AutoWithdrawalReward = &coin
+				} else {
+					return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
 func (sf *WrapperMsgDelegate) ParseRelevantData() []parsingTypes.MessageRelevantInformation {
+	var relevantData []parsingTypes.MessageRelevantInformation
+	if sf.AutoWithdrawalReward != nil {
+		data := parsingTypes.MessageRelevantInformation{}
+		data.AmountReceived = sf.AutoWithdrawalReward.Amount.BigInt()
+		data.DenominationReceived = sf.AutoWithdrawalReward.Denom
+		data.ReceiverAddress = sf.DelegatorAddress
+		relevantData = append(relevantData, data)
+	}
+	return relevantData
+}
+
+func (sf *WrapperMsgUndelegate) ParseRelevantData() []parsingTypes.MessageRelevantInformation {
 	var relevantData []parsingTypes.MessageRelevantInformation
 	if sf.AutoWithdrawalReward != nil {
 		data := parsingTypes.MessageRelevantInformation{}
@@ -69,4 +137,11 @@ func (sf *WrapperMsgDelegate) String() string {
 		return fmt.Sprintf("MsgDelegate: Delegator %s did not auto-withdrawal rewards\n", sf.DelegatorAddress)
 	}
 	return fmt.Sprintf("MsgDelegate: Delegator %s auto-withdrew %s\n", sf.DelegatorAddress, sf.AutoWithdrawalReward)
+}
+
+func (sf *WrapperMsgUndelegate) String() string {
+	if sf.AutoWithdrawalReward == nil {
+		return fmt.Sprintf("MsgUndelegate: Delegator %s did not auto-withdrawal rewards\n", sf.DelegatorAddress)
+	}
+	return fmt.Sprintf("MsgUndelegate: Delegator %s auto-withdrew %s\n", sf.DelegatorAddress, sf.AutoWithdrawalReward)
 }

--- a/csv/parsers/accointing/accointing.go
+++ b/csv/parsers/accointing/accointing.go
@@ -267,6 +267,8 @@ func ParseTx(address string, events []db.TaxableTransaction) ([]parsers.CsvRow, 
 			rows = append(rows, ParseMsgWithdrawDelegatorReward(address, event))
 		} else if staking.IsMsgDelegate[event.Message.MessageType] {
 			rows = append(rows, ParseMsgWithdrawDelegatorReward(address, event))
+		} else if staking.IsMsgUndelegate[event.Message.MessageType] {
+			rows = append(rows, ParseMsgWithdrawDelegatorReward(address, event))
 		} else if gamm.IsMsgSwapExactAmountIn[event.Message.MessageType] {
 			rows = append(rows, ParseMsgSwapExactAmountIn(address, event))
 		} else if gamm.IsMsgSwapExactAmountOut[event.Message.MessageType] {


### PR DESCRIPTION
Only indexes data when the coin received event contains the delegator address as a recipient

Tested on the following blocks and txes with rewards withdrawn:
* Block: 6275550
  Tx: 94EAAC222901EB6A6E567EA4B08EF939E1778429342466F3C41F72C3ED61CEF3
* Block: 6275540
  Tx: AE4FAE9619E871A0615FFBE46686A351F03C3B5BED1D4622C7C159A86ACDDB8A

Tested on the following block and tx without rewards withdrawn:
* Block: 6275482
* Tx: 51DE4DC3943CBBCEF25A0C2A1417B2342D4169BF5555FA831E39961B0CE15742
