### PR TITLE
Indexer and CSV accointing parser for MsgBeginRedelegate

### DIFF
--- a/core/tx.go
+++ b/core/tx.go
@@ -38,6 +38,7 @@ var messageTypeHandler = map[string]func() txTypes.CosmosMessage{
 	"/cosmos.distribution.v1beta1.MsgFundCommunityPool":           func() txTypes.CosmosMessage { return &distribution.WrapperMsgFundCommunityPool{} },
 	"/cosmos.staking.v1beta1.MsgDelegate":                         func() txTypes.CosmosMessage { return &staking.WrapperMsgDelegate{} },
 	"/cosmos.staking.v1beta1.MsgUndelegate":                       func() txTypes.CosmosMessage { return &staking.WrapperMsgUndelegate{} },
+	"/cosmos.staking.v1beta1.MsgBeginRedelegate":                  func() txTypes.CosmosMessage { return &staking.WrapperMsgBeginRedelegate{} },
 }
 
 //Merge the chain specific message type handlers into the core message type handler map

--- a/cosmos/modules/staking/types.go
+++ b/cosmos/modules/staking/types.go
@@ -2,6 +2,7 @@ package staking
 
 import (
 	"fmt"
+	"strings"
 
 	txModule "github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules/tx"
 
@@ -19,6 +20,10 @@ var IsMsgUndelegate = map[string]bool{
 	"/cosmos.staking.v1beta1.MsgUndelegate": true,
 }
 
+var IsMsgBeginRedelegate = map[string]bool{
+	"/cosmos.staking.v1beta1.MsgBeginRedelegate": true,
+}
+
 type WrapperMsgDelegate struct {
 	txModule.Message
 	CosmosMsgDelegate    *stakeTypes.MsgDelegate
@@ -31,6 +36,13 @@ type WrapperMsgUndelegate struct {
 	CosmosMsgUndelegate  *stakeTypes.MsgUndelegate
 	DelegatorAddress     string
 	AutoWithdrawalReward *stdTypes.Coin
+}
+
+type WrapperMsgBeginRedelegate struct {
+	txModule.Message
+	CosmosMsgBeginRedelegate *stakeTypes.MsgBeginRedelegate
+	DelegatorAddress         string
+	AutoWithdrawalRewards    stdTypes.Coins
 }
 
 //HandleMsg: Handle type checking for MsgFundCommunityPool
@@ -108,6 +120,52 @@ func (sf *WrapperMsgUndelegate) HandleMsg(msgType string, msg stdTypes.Msg, log 
 	return nil
 }
 
+//HandleMsg: Handle type checking for MsgFundCommunityPool
+func (sf *WrapperMsgBeginRedelegate) HandleMsg(msgType string, msg stdTypes.Msg, log *txModule.TxLogMessage) error {
+	sf.Type = msgType
+	sf.CosmosMsgBeginRedelegate = msg.(*stakeTypes.MsgBeginRedelegate)
+
+	//Confirm that the action listed in the message log matches the Message type
+	valid_log := txModule.IsMessageActionEquals(sf.GetType(), log)
+	if !valid_log {
+		return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
+	}
+
+	//The attribute in the log message that shows you the delegator rewards auto-received
+	delegatorReceivedCoinsEvt := txModule.GetEventWithType(bankTypes.EventTypeCoinReceived, log)
+	sf.DelegatorAddress = sf.CosmosMsgBeginRedelegate.DelegatorAddress
+	if delegatorReceivedCoinsEvt == nil {
+		sf.AutoWithdrawalRewards = make(stdTypes.Coins, 0)
+	} else {
+		var receivers []string
+		var amounts []string
+
+		//Pair off amounts and receivers in order
+		for _, v := range delegatorReceivedCoinsEvt.Attributes {
+			if v.Key == "receiver" {
+				receivers = append(receivers, v.Value)
+			} else if v.Key == "amount" {
+				amounts = append(amounts, v.Value)
+			}
+		}
+
+		//Find delegator address in receivers if its there, find its paired amount and set as the withdrawn rewards
+		//We use a cosmos.Coins array type for redelegations as redelegating could force withdrawal from both validators
+		for i, v := range receivers {
+			if v == sf.DelegatorAddress {
+				coin, err := stdTypes.ParseCoinNormalized(amounts[i])
+				if err == nil {
+					sf.AutoWithdrawalRewards = append(sf.AutoWithdrawalRewards, coin)
+				} else {
+					return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
 func (sf *WrapperMsgDelegate) ParseRelevantData() []parsingTypes.MessageRelevantInformation {
 	var relevantData []parsingTypes.MessageRelevantInformation
 	if sf.AutoWithdrawalReward != nil {
@@ -132,6 +190,18 @@ func (sf *WrapperMsgUndelegate) ParseRelevantData() []parsingTypes.MessageReleva
 	return relevantData
 }
 
+func (sf *WrapperMsgBeginRedelegate) ParseRelevantData() []parsingTypes.MessageRelevantInformation {
+	var relevantData []parsingTypes.MessageRelevantInformation
+	for _, coin := range sf.AutoWithdrawalRewards {
+		data := parsingTypes.MessageRelevantInformation{}
+		data.AmountReceived = coin.Amount.BigInt()
+		data.DenominationReceived = coin.Denom
+		data.ReceiverAddress = sf.DelegatorAddress
+		relevantData = append(relevantData, data)
+	}
+	return relevantData
+}
+
 func (sf *WrapperMsgDelegate) String() string {
 	if sf.AutoWithdrawalReward == nil {
 		return fmt.Sprintf("MsgDelegate: Delegator %s did not auto-withdrawal rewards\n", sf.DelegatorAddress)
@@ -144,4 +214,17 @@ func (sf *WrapperMsgUndelegate) String() string {
 		return fmt.Sprintf("MsgUndelegate: Delegator %s did not auto-withdrawal rewards\n", sf.DelegatorAddress)
 	}
 	return fmt.Sprintf("MsgUndelegate: Delegator %s auto-withdrew %s\n", sf.DelegatorAddress, sf.AutoWithdrawalReward)
+}
+
+func (sf *WrapperMsgBeginRedelegate) String() string {
+
+	var coinsRecievedStrings []string
+	for _, coin := range sf.AutoWithdrawalRewards {
+		coinsRecievedStrings = append(coinsRecievedStrings, coin.String())
+	}
+
+	if len(coinsRecievedStrings) > 0 {
+		return fmt.Sprintf("MsgBeginRedelegate: Delegator %s auto-withdrew %s\n", sf.DelegatorAddress, strings.Join(coinsRecievedStrings, ", "))
+	}
+	return fmt.Sprintf("MsgBeginRedelegate: Delegator %s did not auto-withdrawal rewards\n", sf.DelegatorAddress)
 }

--- a/csv/parsers/accointing/accointing.go
+++ b/csv/parsers/accointing/accointing.go
@@ -269,6 +269,8 @@ func ParseTx(address string, events []db.TaxableTransaction) ([]parsers.CsvRow, 
 			rows = append(rows, ParseMsgWithdrawDelegatorReward(address, event))
 		} else if staking.IsMsgUndelegate[event.Message.MessageType] {
 			rows = append(rows, ParseMsgWithdrawDelegatorReward(address, event))
+		} else if staking.IsMsgBeginRedelegate[event.Message.MessageType] {
+			rows = append(rows, ParseMsgWithdrawDelegatorReward(address, event))
 		} else if gamm.IsMsgSwapExactAmountIn[event.Message.MessageType] {
 			rows = append(rows, ParseMsgSwapExactAmountIn(address, event))
 		} else if gamm.IsMsgSwapExactAmountOut[event.Message.MessageType] {


### PR DESCRIPTION
Only indexes data when the coin received event contains the delegator address as a recipient. Can contain multiple receive events if delegator is owed rewards on both validators, so we use a cosmos.Coins array and pair up all delegator receipts and amounts.

Tested on blocks:
* Block: 6275316
   Tx: 23D72905799931C68D7CCE18D7B0C82C9AE34B7AE26A7748B93F78169FB877AB
   This has a redelegation where a reward was forced.
* Block: 6275371
   Tx: 11A6E7BBFBB0573829A5431868030647AB1193DFBC0DD1BA3505735AA797DE18
   This has a redelegation where no reward was forced.
