### PR TITLE
Indexing refactor

### DIFF
--- a/cmd/index.go
+++ b/cmd/index.go
@@ -208,9 +208,13 @@ func indexOsmosisRewards(wg *sync.WaitGroup, config *config.Config, cl *client.C
 		startHeight = OsmosisGetRewardsStartIndexHeight(db, config.Lens.ChainID)
 	}
 
-	endHeight, err := rpc.GetLatestBlockHeight(cl)
-	if err != nil {
-		configHelpers.Log.Fatal("Error getting blockchain latest height.", zap.Error(err))
+	endHeight := config.Base.EndBlock
+	if endHeight == -1 {
+		var err error
+		endHeight, err = rpc.GetLatestBlockHeight(cl)
+		if err != nil {
+			configHelpers.Log.Fatal("Error getting blockchain latest height.", zap.Error(err))
+		}
 	}
 
 	rpcClient := osmosis.URIClient{

--- a/cmd/index.go
+++ b/cmd/index.go
@@ -109,7 +109,7 @@ func index(cmd *cobra.Command, args []string) {
 	wg.Add(1)
 
 	//Add jobs to the queue to be processed
-	if !config.Base.OsmosisRewardsOnly {
+	if !config.Base.OsmosisRewardsOnly { //TODO: if we are putting this behind an if check, should we do the same with the go routines related to it?
 		enqueueBlocksToProcess(config, cl, db, blockChan)
 	}
 

--- a/cmd/index.go
+++ b/cmd/index.go
@@ -284,14 +284,14 @@ func ProcessTxs(results chan *indexerTx.GetTxsEventResponseWrapper, numBlocksTim
 		txToProcess := <-results
 		txDBWrappers, err := core.ProcessRpcTxs(db, txToProcess.CosmosGetTxsEventResponse)
 		if err != nil {
-			config.Logger.Error("ProcessRpcTxs: unhandled error", zap.Error(err))
+			config.Log.Error("ProcessRpcTxs: unhandled error", zap.Error(err))
 			failedBlockHandler(txToProcess.Height, core.UnprocessableTxError, err)
 		}
 
 		//While debugging we'll sometimes want to turn off INSERTS to the DB
 		//Note that this does not turn off certain reads or DB connections.
 		if indexingEnabled {
-			log.Printf("Indexing block %d, threaded.\n", txToProcess.Height)
+			config.Log.Info(fmt.Sprintf("Indexing block %d, threaded.\n", txToProcess.Height))
 			err = dbTypes.IndexNewBlock(db, txToProcess.Height, txDBWrappers, chainID, chainName)
 			if err != nil {
 				if err != nil {

--- a/cmd/index.go
+++ b/cmd/index.go
@@ -240,6 +240,8 @@ func indexOsmosisRewards(wg *sync.WaitGroup, config *config.Config, cl *client.C
 		_, err := indexOsmosisReward(db, chainID, chainName, rpcClient, epoch)
 		for err != nil && attempts < maxAttempts {
 			attempts++
+			// for some reason these need an exponential backoff....
+			time.Sleep(time.Second * time.Duration(math.Pow(2, float64(attempts))))
 			code, err := indexOsmosisReward(db, chainID, chainName, rpcClient, epoch)
 			if err != nil && attempts == maxAttempts {
 				failedBlockHandler(epoch, code, err)

--- a/cmd/index.go
+++ b/cmd/index.go
@@ -219,15 +219,15 @@ func indexOsmosisRewards(wg *sync.WaitGroup, config *config.Config, cl *client.C
 	}
 
 	for epoch := startHeight; epoch <= endHeight; epoch++ {
-		rewards, indexErr := rpcClient.GetEpochRewards(epoch)
-		if indexErr != nil {
-			failedBlockHandler(epoch, core.OsmosisNodeRewardLookupError, indexErr)
+		rewards, err := rpcClient.GetEpochRewards(epoch)
+		if err != nil {
+			failedBlockHandler(epoch, core.OsmosisNodeRewardLookupError, err)
 		}
 
 		if len(rewards) > 0 {
-			indexErr = dbTypes.IndexOsmoRewards(db, chainID, chainName, rewards)
-			if indexErr != nil {
-				failedBlockHandler(epoch, core.OsmosisNodeRewardIndexError, indexErr)
+			err = dbTypes.IndexOsmoRewards(db, chainID, chainName, rewards)
+			if err != nil {
+				failedBlockHandler(epoch, core.OsmosisNodeRewardIndexError, err)
 			}
 		}
 	}
@@ -235,7 +235,7 @@ func indexOsmosisRewards(wg *sync.WaitGroup, config *config.Config, cl *client.C
 
 func queryRpc(blockChan chan int64, blockTXs chan *indexerTx.GetTxsEventResponseWrapper, cl *client.ChainClient, failedBlockHandler func(height int64, code core.BlockProcessingFailure, err error)) {
 	reprocessBlock := int64(0)
-
+	//FIXME: add logic to only retry block N times, if block fails, add to failed block table in DB
 	for {
 		blockToProcess := reprocessBlock
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"go.uber.org/zap"
+	"log"
 	"os"
 	"time"
 
@@ -47,7 +48,9 @@ func initConfig() {
 	} else {
 		// Find home directory.
 		home, err := os.UserHomeDir()
-		cobra.CheckErr(err)
+		if err != nil {
+			log.Fatalf("Failed to find user home dir. Err: %v", err)
+		}
 		defaultCfgLocation := fmt.Sprintf("%s/.cosmos-tax-cli", home)
 
 		viper.AddConfigPath(defaultCfgLocation)
@@ -55,18 +58,24 @@ func initConfig() {
 		viper.SetConfigName("config")
 	}
 
-	//TODO: What do we do on first time app run if config file doesnt exit?
 	//Load defaults into a file at $HOME?
-	//Require users to run an init command?
-	if err := viper.ReadInConfig(); err == nil {
-		err := viper.Unmarshal(&conf)
-		cobra.CheckErr(err)
-		//TODO: validate the config by making sure values exist for required struct values
-		//Either set required values on Viper or
-		//Write a function to check explicitly
-		//Consider creating a set of defaults
-	} else {
-		cobra.CheckErr(err)
+	err := viper.ReadInConfig()
+	if err != nil {
+		log.Fatalf("Failed to read config file. Err: %v", err)
+	}
+
+	// Unmarshal the config into struct
+	err = viper.Unmarshal(&conf)
+	if err != nil {
+		log.Fatalf("Failed to unmarshal config. Err: %v", err)
+	}
+
+	//TODO: Consider creating a set of defaults
+
+	// Validate config
+	err = conf.Validate()
+	if err != nil {
+		log.Fatalf("Failed to validate config. Err: %v", err)
 	}
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -91,7 +91,7 @@ func setup(config config.Config) (*configHelpers.Config, *gorm.DB, *gocron.Sched
 	db, err := dbTypes.PostgresDbConnect(config.Database.Host, config.Database.Port, config.Database.Database,
 		config.Database.User, config.Database.Password, config.Log.Level)
 	if err != nil {
-		configHelpers.Log.Error("Could not establish connection to the database", zap.Error(err))
+		configHelpers.Log.Fatal("Could not establish connection to the database", zap.Error(err))
 	}
 
 	sqldb, _ := db.DB()

--- a/config/app_config.go
+++ b/config/app_config.go
@@ -1,7 +1,9 @@
 package config
 
 import (
+	"errors"
 	"github.com/BurntSushi/toml"
+	"github.com/DefiantLabs/cosmos-tax-cli/util"
 	"github.com/imdario/mergo"
 	lg "log"
 )
@@ -13,6 +15,72 @@ type Config struct {
 	Base               base
 	Log                log
 	Lens               lens
+}
+
+// Validate will validate the config for required fields
+func (conf *Config) Validate() error {
+	// Database Checks
+	if util.StrNotSet(conf.Database.Host) {
+		return errors.New("database host must be set")
+	}
+	if util.StrNotSet(conf.Database.Port) {
+		return errors.New("database port must be set")
+	}
+	if util.StrNotSet(conf.Database.Database) {
+		return errors.New("database name (i.e. Database) must be set")
+	}
+	if util.StrNotSet(conf.Database.User) {
+		return errors.New("database user must be set")
+	}
+	if util.StrNotSet(conf.Database.Password) {
+		return errors.New("database password must be set")
+	}
+
+	// Base Checks
+	if util.StrNotSet(conf.Base.AddressRegex) {
+		return errors.New("base addressRegex must be set")
+	}
+	if util.StrNotSet(conf.Base.AddressPrefix) {
+		return errors.New("base addressPrefix must be set")
+	}
+	if conf.Base.StartBlock == 0 { //TODO: Verify that 0 is not a valid starting block..
+		return errors.New("base startblock must be set")
+	}
+	if conf.Base.EndBlock == 0 {
+		return errors.New("base endblock must be set")
+	}
+	// Throttling can safely default to 0
+	// BlockTimer can safely default to 0
+	// WaitForChain can safely default to false
+	// WaitForChainDelay can safely default to 0
+	// IndexingEnabled can safely default to false TODO: but do we want this?
+	// ExitWhenCaughtUp can safely default to false
+	// OsmosisRewardsOnly can safely default to false
+
+	// Log
+	// Both level and path can safely be blank
+
+	// Lens
+	if util.StrNotSet(conf.Lens.Rpc) {
+		return errors.New("lens rpc must be set")
+	}
+	if util.StrNotSet(conf.Lens.Key) {
+		return errors.New("lens key must be set")
+	}
+	if util.StrNotSet(conf.Lens.AccountPrefix) {
+		return errors.New("lens accountPrefix must be set")
+	}
+	if util.StrNotSet(conf.Lens.KeyringBackend) {
+		return errors.New("lens keyringBackend must be set")
+	}
+	if util.StrNotSet(conf.Lens.ChainID) {
+		return errors.New("lens chainID must be set")
+	}
+	if util.StrNotSet(conf.Lens.ChainName) {
+		return errors.New("lens chainName must be set")
+	}
+
+	return nil
 }
 
 type database struct {

--- a/config/lens_helper.go
+++ b/config/lens_helper.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	lensClient "github.com/strangelove-ventures/lens/client"
+	"go.uber.org/zap"
 )
 
 func GetLensClient(conf lens) *lensClient.ChainClient {
@@ -9,7 +10,10 @@ func GetLensClient(conf lens) *lensClient.ChainClient {
 	//You can use lens default settings to generate that directory appropriately then move it to the desired path.
 	//For example, 'lens keys restore default' will restore the key to the default keyring (e.g. /home/kyle/.lens/...)
 	//and you can move all of the necessary keys to whatever homepath you want to use. Or you can use --home flag.
-	cl, _ := lensClient.NewChainClient(GetLensConfig(conf, true), conf.Homepath, nil, nil)
+	cl, err := lensClient.NewChainClient(GetLensConfig(conf, true), conf.Homepath, nil, nil)
+	if err != nil {
+		Log.Fatal("Error connecting to cain.", zap.Error(err))
+	}
 	return cl
 }
 

--- a/config/logger.go
+++ b/config/logger.go
@@ -6,17 +6,24 @@ import (
 	lg "log"
 )
 
-var Logger *zap.Logger //Global logger
+var Log *zap.Logger //Global logger
 
 func DoConfigureLogger(logPath string, logLevel string) {
+	// only log to path if set
+	outputPaths := []string{"stdout"}
+	if len(logPath) > 0 {
+		outputPaths = append(outputPaths, logPath)
+	}
+
 	//Logger
 	cfg := zap.Config{
-		OutputPaths: []string{logPath},
+		OutputPaths: outputPaths,
 		EncoderConfig: zapcore.EncoderConfig{
 			MessageKey:  "message",
 			LevelKey:    "level",
 			EncodeLevel: zapcore.LowercaseLevelEncoder,
 			EncodeTime:  zapcore.ISO8601TimeEncoder,
+			TimeKey:     "timestamp",
 		},
 		Encoding: "json",
 		Level:    zap.NewAtomicLevel(),
@@ -28,7 +35,7 @@ func DoConfigureLogger(logPath string, logLevel string) {
 	}
 
 	cfg.Level = al
-	Logger, err = cfg.Build()
+	Log, err = cfg.Build()
 	if err != nil {
 		lg.Fatalf("logger setup failure. Err: %v", err)
 	}

--- a/core/processor.go
+++ b/core/processor.go
@@ -1,6 +1,10 @@
 package core
 
-import "fmt"
+import (
+	"fmt"
+	"github.com/DefiantLabs/cosmos-tax-cli/config"
+	"go.uber.org/zap"
+)
 
 type BlockProcessingFailure int
 
@@ -25,5 +29,5 @@ func HandleFailedBlock(height int64, code BlockProcessingFailure, err error) {
 		reason = "Failed Osmosis rewards indexing for block"
 	}
 
-	fmt.Printf("%s %d, details: %s", reason, height, err.Error())
+	config.Log.Error(fmt.Sprintf("Block %v failed. Reason: %v", height, reason), zap.Error(err))
 }

--- a/core/tx.go
+++ b/core/tx.go
@@ -196,7 +196,6 @@ func ProcessTx(db *gorm.DB, tx txTypes.MergedTx) (txDBWapper dbTypes.TxDBWrapper
 	timeStamp, err := time.Parse(time.RFC3339, tx.TxResponse.TimeStamp)
 	if err != nil {
 		config.Log.Error("Error parsing tx timestamp.", zap.Error(err))
-		// FIXME: should we return or panic here?
 	}
 
 	code := tx.TxResponse.Code

--- a/core/tx.go
+++ b/core/tx.go
@@ -221,7 +221,7 @@ func ProcessTx(db *gorm.DB, tx txTypes.MergedTx) (txDBWapper dbTypes.TxDBWrapper
 			messageLog := txTypes.GetMessageLogForIndex(tx.TxResponse.Log, messageIndex)
 			cosmosMessage, err := ParseCosmosMessage(message, messageLog)
 			if err != nil {
-				log.Printf("[Block: %v] ParseCosmosMessage failed. Err: %v", tx.TxResponse.Height, err)
+				config.Log.Warn(fmt.Sprintf("[Block: %v] ParseCosmosMessage failed.", tx.TxResponse.Height), zap.Error(err))
 
 				//type cast on error allows getting message type if it was parsed correctly
 				re, ok := err.(*txTypes.UnknownMessageError)
@@ -237,7 +237,7 @@ func ProcessTx(db *gorm.DB, tx txTypes.MergedTx) (txDBWapper dbTypes.TxDBWrapper
 				//spew.Dump(message)
 				//println("\n------------------END MESSAGE----------------------\n")
 			} else {
-				log.Printf("[Block: %v] Cosmos message of known type: %s", tx.TxResponse.Height, cosmosMessage)
+				config.Log.Debug(fmt.Sprintf("[Block: %v] Cosmos message of known type: %s", tx.TxResponse.Height, cosmosMessage))
 				currMessage.MessageType = cosmosMessage.GetType()
 				currMessageDBWrapper.Message = currMessage
 
@@ -259,11 +259,11 @@ func ProcessTx(db *gorm.DB, tx txTypes.MergedTx) (txDBWapper dbTypes.TxDBWrapper
 							denomSent, err = dbTypes.GetDenomForBase(v.DenominationSent)
 							if err != nil {
 								//attempt to add missing denoms to the database
-								config.Logger.Error("Denom lookup", zap.Error(err), zap.String("denom sent", v.DenominationSent))
+								config.Log.Error("Denom lookup", zap.Error(err), zap.String("denom sent", v.DenominationSent))
 
 								denomSent, err = dbTypes.AddUnknownDenom(db, v.DenominationSent)
 								if err != nil {
-									config.Logger.Error("There was an error adding a missing denom", zap.Error(err), zap.String("denom received", v.DenominationSent))
+									config.Log.Error("There was an error adding a missing denom", zap.Error(err), zap.String("denom received", v.DenominationSent))
 									return txDBWapper, err
 								}
 							}
@@ -277,10 +277,10 @@ func ProcessTx(db *gorm.DB, tx txTypes.MergedTx) (txDBWapper dbTypes.TxDBWrapper
 
 							if err != nil {
 								//attempt to add missing denoms to the database
-								config.Logger.Error("Denom lookup", zap.Error(err), zap.String("denom received", v.DenominationReceived))
+								config.Log.Error("Denom lookup", zap.Error(err), zap.String("denom received", v.DenominationReceived))
 								denomReceived, err = dbTypes.AddUnknownDenom(db, v.DenominationReceived)
 								if err != nil {
-									config.Logger.Error("There was an error adding a missing denom", zap.Error(err), zap.String("denom received", v.DenominationReceived))
+									config.Log.Error("There was an error adding a missing denom", zap.Error(err), zap.String("denom received", v.DenominationReceived))
 									return txDBWapper, err
 								}
 							}

--- a/cosmos/modules/tx/types.go
+++ b/cosmos/modules/tx/types.go
@@ -52,7 +52,7 @@ type TxResponse struct {
 	TxHash    string         `json:"txhash"`
 	Height    string         `json:"height"`
 	TimeStamp string         `json:"timestamp"`
-	Code      int64          `json:"code"`
+	Code      uint32         `json:"code"`
 	RawLog    string         `json:"raw_log"`
 	Log       []TxLogMessage `json:"logs"`
 }

--- a/db/models.go
+++ b/db/models.go
@@ -13,6 +13,13 @@ type Block struct {
 	Chain        Chain `gorm:"foreignKey:BlockchainID"`
 }
 
+type FailedBlock struct {
+	ID           uint
+	Height       int64 `gorm:"uniqueIndex:failedchainheight"`
+	BlockchainID uint  `gorm:"uniqueIndex:failedchainheight"`
+	Chain        Chain `gorm:"foreignKey:BlockchainID"`
+}
+
 type Chain struct {
 	ID      uint   `gorm:"primaryKey"`
 	ChainID string `gorm:"uniqueIndex"` //e.g. osmosis-1

--- a/db/models.go
+++ b/db/models.go
@@ -23,7 +23,7 @@ type Tx struct {
 	ID              uint
 	TimeStamp       time.Time
 	Hash            string
-	Code            int64
+	Code            uint32
 	BlockId         uint
 	Block           Block
 	SignerAddressId *int //*int allows foreign key to be null

--- a/osmosis/rewards.go
+++ b/osmosis/rewards.go
@@ -41,7 +41,7 @@ func (client *URIClient) GetRewardsBetween(startHeight int64, endHeight int64) (
 func (client *URIClient) GetEpochRewards(height int64) ([]*OsmosisRewards, error) {
 	rewards, err := client.getRewards(height)
 	if err != nil {
-		config.Log.Error(fmt.Sprintf("Error processing epoch %d\n", height), zap.Error(err))
+		config.Log.Error(fmt.Sprintf("Error getting rewards for epoch %d\n", height), zap.Error(err))
 		return nil, err
 	}
 	return rewards, nil

--- a/osmosis/rewards.go
+++ b/osmosis/rewards.go
@@ -3,6 +3,8 @@ package osmosis
 import (
 	"context"
 	"fmt"
+	"github.com/DefiantLabs/cosmos-tax-cli/config"
+	"go.uber.org/zap"
 	"strings"
 	"time"
 
@@ -37,12 +39,11 @@ func (client *URIClient) GetRewardsBetween(startHeight int64, endHeight int64) (
 // If a block does not contain a reward distribution, it gets skipped.
 // An error indicates a problem with the RPC search or the DB indexer.
 func (client *URIClient) GetEpochRewards(height int64) ([]*OsmosisRewards, error) {
-	rewards, epochErr := client.getRewards(height)
-	if epochErr != nil {
-		fmt.Printf("Error %s processing epoch %d\n", epochErr.Error(), height)
-		return nil, epochErr
+	rewards, err := client.getRewards(height)
+	if err != nil {
+		config.Log.Error(fmt.Sprintf("Error processing epoch %d\n", height), zap.Error(err))
+		return nil, err
 	}
-
 	return rewards, nil
 }
 
@@ -63,10 +64,9 @@ func (client *URIClient) getRewardEpochs(startHeight int64, endHeight int64) ([]
 		query := fmt.Sprintf("block.height = %d AND %s", i, osmosisRewardsQuery)
 		page := 1
 		per_page := 30
-		blockSearch, blockSearchErr := client.DoBlockSearch(context.Background(), query, &page, &per_page, "desc")
-
-		if blockSearchErr != nil {
-			return nil, blockSearchErr
+		blockSearch, err := client.DoBlockSearch(context.Background(), query, &page, &per_page, "desc")
+		if err != nil {
+			return nil, err
 		}
 
 		for _, block := range blockSearch.Blocks {

--- a/rpc_test.go
+++ b/rpc_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	configHelpers "github.com/DefiantLabs/cosmos-tax-cli/config"
+	"github.com/DefiantLabs/cosmos-tax-cli/config"
 	"github.com/DefiantLabs/cosmos-tax-cli/core"
 
 	"github.com/strangelove-ventures/lens/client"
@@ -23,8 +23,8 @@ import (
 //   - Returns various values used throughout the application
 //
 //nolint:unused
-func setup_rpc() (*configHelpers.Config, *gocron.Scheduler, error) {
-	argConfig, err := configHelpers.ParseArgs(os.Stderr, os.Args[1:])
+func setup_rpc() (*config.Config, *gocron.Scheduler, error) {
+	argConfig, err := config.ParseArgs(os.Stderr, os.Args[1:])
 
 	if err != nil {
 		return nil, nil, err
@@ -37,18 +37,18 @@ func setup_rpc() (*configHelpers.Config, *gocron.Scheduler, error) {
 		location = "./config.toml"
 	}
 
-	fileConfig, err := configHelpers.GetConfig(location)
+	fileConfig, err := config.GetConfig(location)
 
 	if err != nil {
 		fmt.Println("Error opening configuration file", err)
 		return nil, nil, err
 	}
 
-	config := configHelpers.MergeConfigs(fileConfig, argConfig)
+	cfg := config.MergeConfigs(fileConfig, argConfig)
 
 	//0 is an invalid starting block, set it to 1
-	if config.Base.StartBlock == 0 {
-		config.Base.StartBlock = 1
+	if cfg.Base.StartBlock == 0 {
+		cfg.Base.StartBlock = 1
 	}
 
 	//TODO: create config values for the prefixes here
@@ -57,7 +57,7 @@ func setup_rpc() (*configHelpers.Config, *gocron.Scheduler, error) {
 	core.SetupAddressPrefix("juno")
 
 	scheduler := gocron.NewScheduler(time.UTC)
-	return &config, scheduler, nil
+	return &cfg, scheduler, nil
 }
 
 func TestRpc(t *testing.T) {

--- a/tasks/denoms.go
+++ b/tasks/denoms.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"os"
 	"time"
 
 	"github.com/DefiantLabs/cosmos-tax-cli/config"
@@ -49,27 +48,23 @@ func UpsertOsmosisDenoms(db *gorm.DB) {
 
 	denomAssets, err := getOsmosisAssetsList(url)
 	if err != nil {
-		config.Log.Error("Download Osmosis Denom Metadata", zap.Error(err))
-		os.Exit(1)
+		config.Log.Fatal("Download Osmosis Denom Metadata", zap.Error(err))
 	} else {
 		denoms := toDenoms(denomAssets)
 		err = dbTypes.UpsertDenoms(db, denoms)
 		if err != nil {
-			config.Log.Error("Upsert Osmosis Denom Metadata", zap.Error(err))
-			os.Exit(1)
+			config.Log.Fatal("Upsert Osmosis Denom Metadata", zap.Error(err))
 		}
 	}
 
 	frontierDenomAssets, err := getOsmosisAssetsList(frontierUrl)
 	if err != nil {
-		config.Log.Error("Download Osmosis Frontier Denom Metadata", zap.Error(err))
-		os.Exit(1)
+		config.Log.Fatal("Download Osmosis Frontier Denom Metadata", zap.Error(err))
 	} else {
 		denoms := toDenoms(frontierDenomAssets)
 		err = dbTypes.UpsertDenoms(db, denoms)
 		if err != nil {
-			config.Log.Error("Upsert Osmosis Frontier Denom Metadata", zap.Error(err))
-			os.Exit(1)
+			config.Log.Fatal("Upsert Osmosis Frontier Denom Metadata", zap.Error(err))
 		}
 	}
 }

--- a/tasks/denoms.go
+++ b/tasks/denoms.go
@@ -3,7 +3,6 @@ package tasks
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"os"
 	"time"
@@ -50,26 +49,26 @@ func UpsertOsmosisDenoms(db *gorm.DB) {
 
 	denomAssets, err := getOsmosisAssetsList(url)
 	if err != nil {
-		config.Logger.Error("Download Osmosis Denom Metadata", zap.Error(err))
+		config.Log.Error("Download Osmosis Denom Metadata", zap.Error(err))
 		os.Exit(1)
 	} else {
 		denoms := toDenoms(denomAssets)
 		err = dbTypes.UpsertDenoms(db, denoms)
 		if err != nil {
-			config.Logger.Error("Upsert Osmosis Denom Metadata", zap.Error(err))
+			config.Log.Error("Upsert Osmosis Denom Metadata", zap.Error(err))
 			os.Exit(1)
 		}
 	}
 
 	frontierDenomAssets, err := getOsmosisAssetsList(frontierUrl)
 	if err != nil {
-		config.Logger.Error("Download Osmosis Frontier Denom Metadata", zap.Error(err))
+		config.Log.Error("Download Osmosis Frontier Denom Metadata", zap.Error(err))
 		os.Exit(1)
 	} else {
 		denoms := toDenoms(frontierDenomAssets)
 		err = dbTypes.UpsertDenoms(db, denoms)
 		if err != nil {
-			config.Logger.Error("Upsert Osmosis Frontier Denom Metadata", zap.Error(err))
+			config.Log.Error("Upsert Osmosis Frontier Denom Metadata", zap.Error(err))
 			os.Exit(1)
 		}
 	}
@@ -117,10 +116,10 @@ func getJson(url string, target interface{}) error {
 }
 
 func DenomUpsertTask(apiHost string, db *gorm.DB) {
-	log.Println("Task started for DenomUpsertTask")
+	config.Log.Debug("Task started for DenomUpsertTask")
 	denomsMetadata, err := rest.GetDenomsMetadatas(apiHost)
 	if err != nil {
-		log.Printf("Error in DenomUpsertTask when reaching out to the API. Err: %v", err)
+		config.Log.Error("Error in DenomUpsertTask when reaching out to the API. ", zap.Error(err))
 		return
 	}
 

--- a/tasks/denoms.go
+++ b/tasks/denoms.go
@@ -2,7 +2,6 @@ package tasks
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"time"
 
@@ -137,9 +136,8 @@ func DenomUpsertTask(apiHost string, db *gorm.DB) {
 
 	err = dbTypes.UpsertDenoms(db, denoms)
 	if err != nil {
-		fmt.Println("Error upserting in DenomUpsertTask")
-		fmt.Println(err)
+		config.Log.Error("Error upserting in DenomUpsertTask", zap.Error(err))
 		return
 	}
-	fmt.Println("Task ended for DenomUpsertTask")
+	config.Log.Info("Task ended for DenomUpsertTask")
 }

--- a/util/utils.go
+++ b/util/utils.go
@@ -51,3 +51,8 @@ func WalkFindStrings(data interface{}, regex *regexp.Regexp) []string {
 		return ret
 	}
 }
+
+// StrNotSet will return true if the string value provided is empty
+func StrNotSet(value string) bool {
+	return len(value) == 0
+}


### PR DESCRIPTION
- Update logger to include timestamps and to default to stdout if log file not provided (https://github.com/DefiantLabs/cosmos-tax-cli/pull/93/commits/228f0bf795ffbbb705f18984d8760c029be76971#diff-c74f41e23643f63c7d3161f9c1adc521d09410b4e2f872bb3a8120f951fbd825)
- Updated code to use logger instead of fmt/log prints
- Add reattempting to the unmarshalling of rewards (https://github.com/DefiantLabs/cosmos-tax-cli/pull/93/commits/c4e192d2583140ad1dc952327894ec3e6ebdce72)
- Update reward indexing to use same block range (https://github.com/DefiantLabs/cosmos-tax-cli/pull/93/commits/ab5277263e91c90b8ac1c267a7c850735f6823ed)
- Prevent index function from returning before all RPC queries are done.(https://github.com/DefiantLabs/cosmos-tax-cli/pull/93/commits/6424d9f95f4abb6cd655b88975b04e60eaa45279)
  - This also included changing our retry behavior to cap it at 5 retries per block.
- Add reattempts to reward indexing (https://github.com/DefiantLabs/cosmos-tax-cli/pull/93/commits/f6b590f1f252e900a8bae950a1b69e5ba9a50a00)
  - This replaces the changes done above for reattempting unmarshalls. Since we need both reattempts, may as well do it at the top...
- Track failed blocks(https://github.com/DefiantLabs/cosmos-tax-cli/pull/93/commits/035c6c821411c705b6aed8c7ed3414468b8ace49)
- Cleanup initConfig to handle errors consistent and validate the config file (https://github.com/DefiantLabs/cosmos-tax-cli/pull/93/commits/668abf6896b52f28da4ef84a6192f372e6fd61a1)
- There were a bunch of confusing duplicate imports. Those have been cleaned up. cfg now refers to a config object/struct, and config refers to the config pkg that contains logging, among other things. (https://github.com/DefiantLabs/cosmos-tax-cli/pull/93/commits/31bba6dc959b2b9746790a92d63e9e9ee57195cc, https://github.com/DefiantLabs/cosmos-tax-cli/pull/93/commits/f643edba8ac4bbf73304990e504c94142d194e8b, https://github.com/DefiantLabs/cosmos-tax-cli/pull/93/commits/2cda582cec5a6c91e452229972c1bd66cfd2f649, https://github.com/DefiantLabs/cosmos-tax-cli/pull/93/commits/f523036a5d8f50fe1e1b2b3906c91b02271ec311)
- Created indexer object to hand stuff off of. Makes function signatures small and easier to read. (https://github.com/DefiantLabs/cosmos-tax-cli/pull/93/commits/96aea50c0c3475d9abca40c6c5174f87c09c36db)
