### PR TITLE
Move message type into new table

### DIFF
--- a/cmd/index.go
+++ b/cmd/index.go
@@ -183,13 +183,12 @@ func (idxr *Indexer) enqueueBlocksToProcess(blockChan chan int64) {
 			}
 
 			//Already at the latest block, wait for the next block to be available.
-			for currBlock <= latestBlock && currBlock <= lastBlock && len(blockChan) != cap(blockChan) {
+			for currBlock <= latestBlock && (currBlock <= lastBlock || lastBlock == -1) && len(blockChan) != cap(blockChan) {
 				if idxr.cfg.Base.Throttling != 0 {
 					time.Sleep(time.Second * time.Duration(idxr.cfg.Base.Throttling))
 				}
 
 				//Add the new block to the queue
-				//fmt.Printf("Added block %d to the queue\n", currBlock)
 				blockChan <- currBlock
 				currBlock++
 			}

--- a/cmd/index.go
+++ b/cmd/index.go
@@ -126,7 +126,7 @@ func index(cmd *cobra.Command, args []string) {
 
 	//Start a thread to process transactions after the RPC querier retrieves them.
 	wg.Add(1)
-	go idxr.processTxs(&wg, blockTXsChan, core.HandleFailedBlock)
+	go idxr.processTxs(&wg, blockTXsChan, core.HandleFailedBlock) // TODO: are we sure more workers here wouldn't make this faster?
 
 	//Osmosis specific indexing requirements. Osmosis distributes rewards to LP holders on a daily basis.
 	if config.IsOsmosis(idxr.cfg) {

--- a/cmd/index.go
+++ b/cmd/index.go
@@ -352,7 +352,7 @@ func (idxr *Indexer) processTxs(wg *sync.WaitGroup, blockTXsChan chan *indexerTx
 			err = dbTypes.IndexNewBlock(idxr.db, txToProcess.Height, txDBWrappers, idxr.cfg.Lens.ChainID, idxr.cfg.Lens.ChainName)
 			if err != nil {
 				if err != nil {
-					log.Fatalf("Error indexing block %v. Err: %v", txToProcess.Height, err)
+					config.Log.Fatal(fmt.Sprintf("Error indexing block %v.", txToProcess.Height), zap.Error(err))
 				}
 			}
 		}

--- a/core/processor.go
+++ b/core/processor.go
@@ -16,6 +16,10 @@ const (
 	OsmosisNodeRewardIndexError
 )
 
+type FailedBlockHandler func(height int64, code BlockProcessingFailure, err error)
+
+// FIXME: this should be renamed, it isn't really handling failed blocks, that is happening elsewhere, this is a failure within a block.
+
 // Log error to stdout. Not much else we can do to handle right now.
 func HandleFailedBlock(height int64, code BlockProcessingFailure, err error) {
 	reason := "{unknown error}"

--- a/core/tx.go
+++ b/core/tx.go
@@ -215,7 +215,7 @@ func ProcessTx(db *gorm.DB, tx txTypes.MergedTx) (txDBWapper dbTypes.TxDBWrapper
 			messageLog := txTypes.GetMessageLogForIndex(tx.TxResponse.Log, messageIndex)
 			cosmosMessage, msgType, err := ParseCosmosMessage(message, messageLog)
 			if err != nil {
-				config.Log.Warn(fmt.Sprintf("[Block: %v] ParseCosmosMessage failed.", tx.TxResponse.Height), zap.Error(err))
+				config.Log.Warn(fmt.Sprintf("[Block: %v] ParseCosmosMessage failed for msg of type '%v'.", tx.TxResponse.Height, msgType), zap.Error(err))
 				currMessageType.MessageType = msgType
 				currMessage.MessageType = currMessageType
 				currMessageDBWrapper.Message = currMessage

--- a/cosmos/modules/distribution/types.go
+++ b/cosmos/modules/distribution/types.go
@@ -2,6 +2,8 @@ package distribution
 
 import (
 	"fmt"
+	"github.com/DefiantLabs/cosmos-tax-cli/config"
+	"go.uber.org/zap"
 
 	txModule "github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules/tx"
 
@@ -111,12 +113,14 @@ func (sf *WrapperMsgWithdrawDelegatorReward) HandleMsg(msgType string, msg stdTy
 	//Confirm that the action listed in the message log matches the Message type
 	valid_log := txModule.IsMessageActionEquals(sf.GetType(), log)
 	if !valid_log {
+		config.Log.Error("Msg log invalid")
 		return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
 	}
 
 	//The attribute in the log message that shows you the delegator withdrawal address and amount received
 	delegatorReceivedCoinsEvt := txModule.GetEventWithType(bankTypes.EventTypeCoinReceived, log)
 	if delegatorReceivedCoinsEvt == nil {
+		config.Log.Error("Failed to get delegatorReceivedCoinsEvt from msg")
 		return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
 	}
 
@@ -128,8 +132,7 @@ func (sf *WrapperMsgWithdrawDelegatorReward) HandleMsg(msgType string, msg stdTy
 	if err != nil {
 		coins, err := stdTypes.ParseCoinsNormalized(coins_received)
 		if err != nil {
-			fmt.Println("Error parsing coins normalized")
-			fmt.Println(err)
+			config.Log.Error("Error parsing coins normalized", zap.Error(err))
 			return err
 		}
 		sf.MultiCoinsReceived = coins

--- a/cosmos/modules/tx/errors.go
+++ b/cosmos/modules/tx/errors.go
@@ -1,18 +1,11 @@
 package tx
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
-type UnknownMessageError struct {
-	MessageType string
-}
-
-func (e *UnknownMessageError) Error() string {
-	return fmt.Sprintf("No message handler for message type '%s'\n", e.MessageType)
-}
-
-func (e *UnknownMessageError) Type() string {
-	return e.MessageType
-}
+var ErrUnknownMessage = errors.New("no message handler for message type")
 
 type MessageLogFormatError struct {
 	Log         string

--- a/csv/parsers/accointing/accointing.go
+++ b/csv/parsers/accointing/accointing.go
@@ -254,28 +254,28 @@ func ParseTx(address string, events []db.TaxableTransaction) ([]parsers.CsvRow, 
 
 	for _, event := range events {
 		//Is this a MsgSend
-		if bank.IsMsgSend[event.Message.MessageType] {
+		if bank.IsMsgSend[event.Message.MessageType.MessageType] {
 			rows = append(rows, ParseMsgSend(address, event))
-		} else if bank.IsMsgMultiSend[event.Message.MessageType] {
+		} else if bank.IsMsgMultiSend[event.Message.MessageType.MessageType] {
 			rows = append(rows, ParseMsgMultiSend(address, event))
-		} else if distribution.IsMsgFundCommunityPool[event.Message.MessageType] {
+		} else if distribution.IsMsgFundCommunityPool[event.Message.MessageType.MessageType] {
 			rows = append(rows, ParseMsgFundCommunityPool(address, event))
-		} else if distribution.IsMsgWithdrawValidatorCommission[event.Message.MessageType] {
+		} else if distribution.IsMsgWithdrawValidatorCommission[event.Message.MessageType.MessageType] {
 			rows = append(rows, ParseMsgWithdrawValidatorCommission(address, event))
-		} else if distribution.IsMsgWithdrawDelegatorReward[event.Message.MessageType] {
+		} else if distribution.IsMsgWithdrawDelegatorReward[event.Message.MessageType.MessageType] {
 			rows = append(rows, ParseMsgWithdrawDelegatorReward(address, event))
-		} else if staking.IsMsgDelegate[event.Message.MessageType] {
+		} else if staking.IsMsgDelegate[event.Message.MessageType.MessageType] {
 			rows = append(rows, ParseMsgWithdrawDelegatorReward(address, event))
-		} else if staking.IsMsgUndelegate[event.Message.MessageType] {
+		} else if staking.IsMsgUndelegate[event.Message.MessageType.MessageType] {
 			rows = append(rows, ParseMsgWithdrawDelegatorReward(address, event))
-		} else if staking.IsMsgBeginRedelegate[event.Message.MessageType] {
+		} else if staking.IsMsgBeginRedelegate[event.Message.MessageType.MessageType] {
 			rows = append(rows, ParseMsgWithdrawDelegatorReward(address, event))
-		} else if gamm.IsMsgSwapExactAmountIn[event.Message.MessageType] {
+		} else if gamm.IsMsgSwapExactAmountIn[event.Message.MessageType.MessageType] {
 			rows = append(rows, ParseMsgSwapExactAmountIn(address, event))
-		} else if gamm.IsMsgSwapExactAmountOut[event.Message.MessageType] {
+		} else if gamm.IsMsgSwapExactAmountOut[event.Message.MessageType.MessageType] {
 			rows = append(rows, ParseMsgSwapExactAmountOut(address, event))
 		} else {
-			fmt.Println("No parser for message type", event.Message.MessageType)
+			fmt.Println("No parser for message type", event.Message.MessageType.MessageType)
 		}
 	}
 

--- a/csv/parsers/accointing/osmosis.go
+++ b/csv/parsers/accointing/osmosis.go
@@ -41,7 +41,7 @@ func (sf *WrapperLpTxGroup) GetRowsForParsingGroup() []parsers.CsvRow {
 }
 
 func (sf *WrapperLpTxGroup) BelongsToGroup(message db.TaxableTransaction) bool {
-	_, isInGroup := IsOsmosisLpTxGroup[message.Message.MessageType]
+	_, isInGroup := IsOsmosisLpTxGroup[message.Message.MessageType.MessageType]
 	return isInGroup
 }
 
@@ -73,7 +73,7 @@ func (sf *WrapperLpTxGroup) ParseGroup() error {
 			row.Date = FormatDatetime(message.Message.Tx.TimeStamp)
 			//We deliberately exclude the GAMM tokens from OutSell/InBuy for Exits/Joins respectively
 			//Accointing has no way of using the GAMM token to determine LP cost basis etc...
-			if _, ok := IsOsmosisExit[message.Message.MessageType]; ok {
+			if _, ok := IsOsmosisExit[message.Message.MessageType.MessageType]; ok {
 				denomRecieved := message.DenominationReceived
 				valueRecieved := message.AmountReceived
 				conversionAmount, conversionSymbol, err := db.ConvertUnits(util.FromNumeric(valueRecieved), denomRecieved)
@@ -88,7 +88,7 @@ func (sf *WrapperLpTxGroup) ParseGroup() error {
 				row.TransactionType = Deposit
 				row.Classification = LiquidityPool
 				sf.Rows = append(sf.Rows, row)
-			} else if _, ok := IsOsmosisJoin[message.Message.MessageType]; ok {
+			} else if _, ok := IsOsmosisJoin[message.Message.MessageType.MessageType]; ok {
 				denomSent := message.DenominationSent
 				valueSent := message.AmountSent
 				conversionAmount, conversionSymbol, err := db.ConvertUnits(util.FromNumeric(valueSent), denomSent)

--- a/db/models.go
+++ b/db/models.go
@@ -55,12 +55,27 @@ type Address struct {
 	Address string `gorm:"uniqueIndex"`
 }
 
+type MessageType struct {
+	ID          uint   `gorm:"primaryKey"`
+	MessageType string `gorm:"uniqueIndex;not null"`
+}
+
+/*
+type UnhandledMessage struct {
+	ID            uint
+	MessageTypeID string `gorm:"foreignKey:MessageTypeID"`
+	MessageIndex  int
+}
+
+*/
+
 type Message struct {
-	ID           uint
-	TxId         uint
-	Tx           Tx
-	MessageType  string `gorm:"index"`
-	MessageIndex int
+	ID            uint
+	TxId          uint
+	Tx            Tx
+	MessageTypeID uint `gorm:"foreignKey:MessageTypeID"`
+	MessageType   MessageType
+	MessageIndex  int
 }
 
 const (
@@ -142,12 +157,12 @@ type TxDBWrapper struct {
 
 // Store messages with their taxable events for easy database creation
 type MessageDBWrapper struct {
-	Message       Message
-	TaxableEvents []TaxableEventDBWrapper
+	Message    Message
+	TaxableTxs []TaxableTxDBWrapper
 }
 
-// Store taxable events with their sender/receiver address for easy database creation
-type TaxableEventDBWrapper struct {
+// Store taxable tx with their sender/receiver address for easy database creation
+type TaxableTxDBWrapper struct {
 	TaxableTx       TaxableTransaction
 	SenderAddress   Address
 	ReceiverAddress Address

--- a/db/search.go
+++ b/db/search.go
@@ -10,7 +10,7 @@ func GetTaxableTransactions(address string, db *gorm.DB) ([]TaxableTransaction, 
 
 	result := db.Joins("JOIN addresses ON addresses.id = taxable_tx.sender_address_id OR addresses.id = taxable_tx.receiver_address_id").
 		Where("addresses.address = ?", address).
-		Preload("Message").Preload("Message.Tx").Preload("Message.Tx.SignerAddress").Preload("Message.Tx.Fees").Preload("Message.Tx.Fees.Denomination").Preload("Message.Tx.Fees.PayerAddress").
+		Preload("Message").Preload("Message.MessageType").Preload("Message.Tx").Preload("Message.Tx.SignerAddress").Preload("Message.Tx.Fees").Preload("Message.Tx.Fees.Denomination").Preload("Message.Tx.Fees.PayerAddress").
 		Preload("SenderAddress").Preload("ReceiverAddress").Preload("DenominationSent").Preload("DenominationReceived").Find(&taxableEvents)
 
 	return taxableEvents, result.Error


### PR DESCRIPTION
This should reduce storage and will potentially make queries of the blocks/transactions we need to reprocess as we support more messages easier.

Also 2 very small changes:
- Cleanup code by making failed block handler func sig a type to be easier to read. (https://github.com/DefiantLabs/cosmos-tax-cli/pull/95/commits/423d87305a9d03e1f10e0a9953691b68dc49f6ac) also added comments to disambiguate with fully failed blocks.
- Fixed bug with enqueueing blocks. (https://github.com/DefiantLabs/cosmos-tax-cli/pull/95/commits/4fd009d0aa3f5e79f5828fa7f6dce122bbea8d13)
- Made changes to error handling of blocks we fail to parse (https://github.com/DefiantLabs/cosmos-tax-cli/pull/95/commits/ce8f973f0a3b95cb26f4a5f417c86bc93bdfda9c)