### PR TITLE
Fix reward upsert

### DIFF
--- a/db/models.go
+++ b/db/models.go
@@ -82,6 +82,7 @@ type TaxableEvent struct {
 	Denomination   Denom   `gorm:"foreignKey:DenominationID"`
 	AddressID      uint    `gorm:"index:idx_addr"`
 	EventAddress   Address `gorm:"foreignKey:AddressID"`
+	EventHash      string
 	BlockID        uint
 	Block          Block `gorm:"foreignKey:BlockID"`
 }

--- a/db/osmosis.go
+++ b/db/osmosis.go
@@ -3,6 +3,7 @@ package db
 import (
 	"crypto/md5"
 	"fmt"
+	"sort"
 
 	"github.com/DefiantLabs/cosmos-tax-cli-private/config"
 	"github.com/DefiantLabs/cosmos-tax-cli-private/osmosis"
@@ -18,6 +19,12 @@ func GetHighestTaxableEventBlock(db *gorm.DB, chainID string) (Block, error) {
 		Joins("JOIN chains ON blocks.blockchain_id = chains.id AND chains.chain_id = ?", chainID).Order("height desc").First(&block)
 
 	return block, result.Error
+}
+
+func eventExists(db *gorm.DB, event TaxableEvent) bool {
+	var count int64
+	db.Model(&TaxableEvent{}).Where("event_hash = ?", event.EventHash).Count(&count)
+	return count > 0
 }
 
 func createTaxableEvents(db *gorm.DB, events []TaxableEvent) error {
@@ -84,6 +91,12 @@ func IndexOsmoRewards(db *gorm.DB, chainID string, chainName string, rewards []*
 			dbEvents = append(dbEvents, evt)
 		}
 	}
+
+	// sort by hash
+	sort.SliceStable(dbEvents, func(i, j int) bool {
+		return dbEvents[i].EventHash < dbEvents[j].EventHash
+	})
+
 	// insert rewards into DB in batches of batchSize
 	batchSize := 500
 	config.Log.Debug(fmt.Sprintf("Rewards ready to insert in DB. Will insert in batches of %v", batchSize))
@@ -92,6 +105,11 @@ func IndexOsmoRewards(db *gorm.DB, chainID string, chainName string, rewards []*
 		if batchEnd > len(dbEvents) {
 			batchEnd = len(dbEvents) - 1
 		}
+		// if this batch has already been inserted, we can skip it
+		if eventExists(db, dbEvents[i]) {
+			continue
+		}
+
 		err := createTaxableEvents(db, dbEvents[i:batchEnd])
 		if err != nil {
 			config.Log.Error("Error storing DB events.", zap.Error(err))

--- a/db/osmosis.go
+++ b/db/osmosis.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"crypto/md5"
 	"fmt"
 
 	"github.com/DefiantLabs/cosmos-tax-cli-private/config"
@@ -74,6 +75,7 @@ func IndexOsmoRewards(db *gorm.DB, chainID string, chainName string, rewards []*
 			evt := TaxableEvent{
 				Source:       OsmosisRewardDistribution,
 				Amount:       util.ToNumeric(coin.Amount.BigInt()),
+				EventHash:    fmt.Sprintf("%x", md5.Sum([]byte(fmt.Sprint(curr.Address, curr.EpochBlockHeight, coin)))),
 				Denomination: denom,
 				// FIXME: will this block have the correct time if it hasn't been indexed yet?
 				Block:        Block{Height: curr.EpochBlockHeight, Chain: Chain{ChainID: chainID, Name: chainName}},


### PR DESCRIPTION
Rewards were duplicated every time the indexer was run. Because there wasn't a great UUID for these events, I decided to add a hash for each one. We can then sort the unordered list using this deterministic hash and check the first record in each batch before doing the insert.

This make the reward indexing idempotent. 