### PR TITLE
Streamline error handling of indexing issues

### DIFF
--- a/core/tx.go
+++ b/core/tx.go
@@ -222,7 +222,7 @@ func ProcessTx(db *gorm.DB, tx txTypes.MergedTx) (txDBWapper dbTypes.TxDBWrapper
 			messageLog := txTypes.GetMessageLogForIndex(tx.TxResponse.Log, messageIndex)
 			cosmosMessage, msgType, err := ParseCosmosMessage(message, messageLog)
 			if err != nil {
-				config.Log.Warn(fmt.Sprintf("[Block: %v] ParseCosmosMessage failed for msg of type '%v'.", tx.TxResponse.Height, msgType), zap.Error(err))
+				config.Log.Warn(fmt.Sprintf("[Block: %v] ParseCosmosMessage failed for msg of type '%v'. We do not currently have a message handler for this message type", tx.TxResponse.Height, msgType))
 				currMessageType.MessageType = msgType
 				currMessage.MessageType = currMessageType
 				currMessageDBWrapper.Message = currMessage

--- a/db/db.go
+++ b/db/db.go
@@ -1,7 +1,6 @@
 package db
 
 import (
-	"errors"
 	"fmt"
 	"github.com/DefiantLabs/cosmos-tax-cli-private/config"
 	"go.uber.org/zap"
@@ -115,7 +114,7 @@ func IndexNewBlock(db *gorm.DB, blockHeight int64, blockTime time.Time, txs []Tx
 					//creates foreign key relation.
 					fee.PayerAddressID = fee.PayerAddress.ID
 				} else if fee.PayerAddress.Address == "" {
-					return errors.New("fee cannot have empty payer address")
+					return fmt.Errorf("fee for tx hash %v cannot have empty payer address", transaction.Tx.Hash)
 				}
 
 				if fee.Denomination.Base == "" || fee.Denomination.Symbol == "" {


### PR DESCRIPTION
Currently, where we run into some issues indexing transactions on a block, we throw a fatal error.

Instead of doing this we should:
- Log an error with why we failed (already doing).
- Add the block to the table/list of failed blocks (included in this PR).
- Continue to the next block for indexing (included in this PR).