### PR TITLE
Message handlers using wrong event or action types

### DIFF
--- a/core/tx.go
+++ b/core/tx.go
@@ -3,14 +3,11 @@ package core
 import (
 	"encoding/hex"
 	"errors"
-	"github.com/DefiantLabs/cosmos-tax-cli-private/cosmos/modules/ibc"
-	"math/big"
-	"strings"
-
 	"github.com/DefiantLabs/cosmos-tax-cli-private/config"
 	parsingTypes "github.com/DefiantLabs/cosmos-tax-cli-private/cosmos/modules"
 	"github.com/DefiantLabs/cosmos-tax-cli-private/cosmos/modules/bank"
 	"github.com/DefiantLabs/cosmos-tax-cli-private/cosmos/modules/distribution"
+	"github.com/DefiantLabs/cosmos-tax-cli-private/cosmos/modules/ibc"
 	"github.com/DefiantLabs/cosmos-tax-cli-private/cosmos/modules/staking"
 	tx "github.com/DefiantLabs/cosmos-tax-cli-private/cosmos/modules/tx"
 	txTypes "github.com/DefiantLabs/cosmos-tax-cli-private/cosmos/modules/tx"
@@ -19,6 +16,7 @@ import (
 	"github.com/DefiantLabs/cosmos-tax-cli-private/util"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
+	"math/big"
 
 	"fmt"
 	"time"
@@ -227,12 +225,10 @@ func ProcessTx(db *gorm.DB, tx txTypes.MergedTx) (txDBWapper dbTypes.TxDBWrapper
 				currMessageType.MessageType = msgType
 				currMessage.MessageType = currMessageType
 				currMessageDBWrapper.Message = currMessage
-				if msgType == distribution.MsgWithdrawDelegatorReward || strings.Contains(fmt.Sprint(*messageLog), "claim") {
-					config.Log.Error(fmt.Sprint(*messageLog))
-					config.Log.Error("This withdraw delegator rewards msg had issues.... PLEASE INVESTIGATE")
-				} else if err != txTypes.ErrUnknownMessage {
+				if err != txTypes.ErrUnknownMessage {
 					//What should we do here? This is an actual error during parsing
 					config.Log.Error("msg parse error.", zap.Error(err))
+					config.Log.Error(tx.TxResponse.TxHash)
 					config.Log.Fatal("Issue parsing a cosmos msg that we DO have a parser for! PLEASE INVESTIGATE")
 				}
 

--- a/core/tx.go
+++ b/core/tx.go
@@ -345,6 +345,7 @@ func ProcessFees(db *gorm.DB, authInfo cosmosTx.AuthInfo) ([]dbTypes.Fee, error)
 				hexPub := hex.EncodeToString(pubKey.Bytes())
 				bechAddr, err := ParseSignerAddress(hexPub, "")
 				if err != nil {
+					config.Log.Error("Error parsing signer address for tx.")
 					fmt.Printf("Err %s\n", err.Error())
 				} else {
 					payerAddr.Address = bechAddr

--- a/core/tx.go
+++ b/core/tx.go
@@ -221,17 +221,18 @@ func ProcessTx(db *gorm.DB, tx txTypes.MergedTx) (txDBWapper dbTypes.TxDBWrapper
 			messageLog := txTypes.GetMessageLogForIndex(tx.TxResponse.Log, messageIndex)
 			cosmosMessage, msgType, err := ParseCosmosMessage(message, messageLog)
 			if err != nil {
-				config.Log.Warn(fmt.Sprintf("[Block: %v] ParseCosmosMessage failed for msg of type '%v'.", tx.TxResponse.Height, msgType), zap.Error(err))
 				currMessageType.MessageType = msgType
 				currMessage.MessageType = currMessageType
 				currMessageDBWrapper.Message = currMessage
 				if err != txTypes.ErrUnknownMessage {
 					//What should we do here? This is an actual error during parsing
-					config.Log.Error("msg parse error.", zap.Error(err))
+					config.Log.Error(fmt.Sprintf("[Block: %v] ParseCosmosMessage failed for msg of type '%v'.", tx.TxResponse.Height, msgType), zap.Error(err))
+					config.Log.Error(fmt.Sprint(messageLog))
 					config.Log.Error(tx.TxResponse.TxHash)
 					config.Log.Fatal("Issue parsing a cosmos msg that we DO have a parser for! PLEASE INVESTIGATE")
-				}
 
+				}
+				config.Log.Warn(fmt.Sprintf("[Block: %v] ParseCosmosMessage failed for msg of type '%v'. We do not currently have a message handler for this message type", tx.TxResponse.Height, msgType))
 				//println("------------------Cosmos message parsing failed. MESSAGE FORMAT FOLLOWS:---------------- \n\n")
 				//spew.Dump(message)
 				//println("\n------------------END MESSAGE----------------------\n")

--- a/core/tx.go
+++ b/core/tx.go
@@ -229,7 +229,7 @@ func ProcessTx(db *gorm.DB, tx txTypes.MergedTx) (txDBWapper dbTypes.TxDBWrapper
 				if err != txTypes.ErrUnknownMessage {
 					//What should we do here? This is an actual error during parsing
 					config.Log.Error("msg parse error.", zap.Error(err))
-					config.Log.Error("Issue parsing a cosmos msg that we DO have a parser for! PLEASE INVESTIGATE")
+					config.Log.Fatal("Issue parsing a cosmos msg that we DO have a parser for! PLEASE INVESTIGATE")
 				}
 
 				//println("------------------Cosmos message parsing failed. MESSAGE FORMAT FOLLOWS:---------------- \n\n")

--- a/core/tx.go
+++ b/core/tx.go
@@ -230,7 +230,6 @@ func ProcessTx(db *gorm.DB, tx txTypes.MergedTx) (txDBWapper dbTypes.TxDBWrapper
 					config.Log.Error(fmt.Sprint(messageLog))
 					config.Log.Error(tx.TxResponse.TxHash)
 					config.Log.Fatal("Issue parsing a cosmos msg that we DO have a parser for! PLEASE INVESTIGATE")
-
 				}
 				config.Log.Warn(fmt.Sprintf("[Block: %v] ParseCosmosMessage failed for msg of type '%v'. We do not currently have a message handler for this message type", tx.TxResponse.Height, msgType))
 				//println("------------------Cosmos message parsing failed. MESSAGE FORMAT FOLLOWS:---------------- \n\n")

--- a/core/tx.go
+++ b/core/tx.go
@@ -226,7 +226,9 @@ func ProcessTx(db *gorm.DB, tx txTypes.MergedTx) (txDBWapper dbTypes.TxDBWrapper
 				currMessageType.MessageType = msgType
 				currMessage.MessageType = currMessageType
 				currMessageDBWrapper.Message = currMessage
-				if err != txTypes.ErrUnknownMessage {
+				if msgType == distribution.MsgWithdrawDelegatorReward {
+					config.Log.Error("This withdraw delegator rewards msg had issues.... PLEASE INVESTIGATE")
+				} else if err != txTypes.ErrUnknownMessage {
 					//What should we do here? This is an actual error during parsing
 					config.Log.Error("msg parse error.", zap.Error(err))
 					config.Log.Fatal("Issue parsing a cosmos msg that we DO have a parser for! PLEASE INVESTIGATE")

--- a/core/tx.go
+++ b/core/tx.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"github.com/DefiantLabs/cosmos-tax-cli-private/cosmos/modules/ibc"
 	"math/big"
+	"strings"
 
 	"github.com/DefiantLabs/cosmos-tax-cli-private/config"
 	parsingTypes "github.com/DefiantLabs/cosmos-tax-cli-private/cosmos/modules"
@@ -226,7 +227,8 @@ func ProcessTx(db *gorm.DB, tx txTypes.MergedTx) (txDBWapper dbTypes.TxDBWrapper
 				currMessageType.MessageType = msgType
 				currMessage.MessageType = currMessageType
 				currMessageDBWrapper.Message = currMessage
-				if msgType == distribution.MsgWithdrawDelegatorReward {
+				if msgType == distribution.MsgWithdrawDelegatorReward || strings.Contains(fmt.Sprint(*messageLog), "claim") {
+					config.Log.Error(fmt.Sprint(*messageLog))
 					config.Log.Error("This withdraw delegator rewards msg had issues.... PLEASE INVESTIGATE")
 				} else if err != txTypes.ErrUnknownMessage {
 					//What should we do here? This is an actual error during parsing

--- a/cosmos/modules/bank/types.go
+++ b/cosmos/modules/bank/types.go
@@ -33,7 +33,7 @@ func (sf *WrapperMsgSend) HandleMsg(msgType string, msg sdk.Msg, log *txModule.L
 	}
 
 	//The attribute in the log message that shows you the delegator withdrawal address and amount received
-	receivedCoinsEvt := txModule.GetEventWithType(bankTypes.EventTypeCoinReceived, log)
+	receivedCoinsEvt := txModule.GetEventWithType(bankTypes.EventTypeTransfer, log)
 	if receivedCoinsEvt == nil {
 		return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
 	}

--- a/cosmos/modules/bank/types.go
+++ b/cosmos/modules/bank/types.go
@@ -38,7 +38,7 @@ func (sf *WrapperMsgSend) HandleMsg(msgType string, msg sdk.Msg, log *txModule.L
 		return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
 	}
 
-	receiverAddress := txModule.GetValueForAttribute(bankTypes.AttributeKeyReceiver, receivedCoinsEvt)
+	receiverAddress := txModule.GetValueForAttribute(bankTypes.AttributeKeyRecipient, receivedCoinsEvt)
 	//coins_received := txModule.GetValueForAttribute("amount", receivedCoinsEvt)
 
 	if sf.CosmosMsgSend.ToAddress != receiverAddress {

--- a/cosmos/modules/bank/types.go
+++ b/cosmos/modules/bank/types.go
@@ -2,6 +2,7 @@ package bank
 
 import (
 	"fmt"
+	"github.com/DefiantLabs/cosmos-tax-cli-private/util"
 	"strings"
 
 	parsingTypes "github.com/DefiantLabs/cosmos-tax-cli-private/cosmos/modules"
@@ -28,7 +29,7 @@ func (sf *WrapperMsgSend) HandleMsg(msgType string, msg sdk.Msg, log *txModule.L
 	//Confirm that the action listed in the message log matches the Message type
 	validLog := txModule.IsMessageActionEquals(sf.GetType(), log)
 	if !validLog {
-		return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
+		return util.ReturnInvalidLog(msgType, log)
 	}
 
 	//The attribute in the log message that shows you the delegator withdrawal address and amount received

--- a/cosmos/modules/distribution/types.go
+++ b/cosmos/modules/distribution/types.go
@@ -2,6 +2,7 @@ package distribution
 
 import (
 	"fmt"
+	"github.com/DefiantLabs/cosmos-tax-cli-private/util"
 
 	"github.com/DefiantLabs/cosmos-tax-cli-private/config"
 	"go.uber.org/zap"
@@ -53,7 +54,7 @@ func (sf *WrapperMsgFundCommunityPool) HandleMsg(msgType string, msg stdTypes.Ms
 	//Confirm that the action listed in the message log matches the Message type
 	validLog := txModule.IsMessageActionEquals(sf.GetType(), log)
 	if !validLog {
-		return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
+		return util.ReturnInvalidLog(msgType, log)
 	}
 
 	//Funds sent and sender address are pulled from the parsed Cosmos Msg
@@ -71,7 +72,7 @@ func (sf *WrapperMsgWithdrawValidatorCommission) HandleMsg(msgType string, msg s
 	//Confirm that the action listed in the message log matches the Message type
 	validLog := txModule.IsMessageActionEquals(sf.GetType(), log)
 	if !validLog {
-		return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
+		return util.ReturnInvalidLog(msgType, log)
 	}
 
 	//The attribute in the log message that shows you the delegator withdrawal address and amount received
@@ -107,8 +108,7 @@ func (sf *WrapperMsgWithdrawDelegatorReward) HandleMsg(msgType string, msg stdTy
 	//Confirm that the action listed in the message log matches the Message type
 	validLog := txModule.IsMessageActionEquals(sf.GetType(), log)
 	if !validLog {
-		config.Log.Error("Msg log invalid")
-		return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
+		return util.ReturnInvalidLog(msgType, log)
 	}
 
 	//The attribute in the log message that shows you the delegator withdrawal address and amount received

--- a/cosmos/modules/distribution/types.go
+++ b/cosmos/modules/distribution/types.go
@@ -110,7 +110,8 @@ func (sf *WrapperMsgWithdrawDelegatorReward) HandleMsg(msgType string, msg stdTy
 	//The attribute in the log message that shows you the delegator withdrawal address and amount received
 	delegatorReceivedCoinsEvt := txModule.GetEventWithType(bankTypes.EventTypeTransfer, log)
 	if delegatorReceivedCoinsEvt == nil {
-		return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
+		// A withdrawal without a transfer means no amounts were actually moved.
+		return nil
 	}
 
 	delegatorAddress := txModule.GetValueForAttribute(bankTypes.AttributeKeyRecipient, delegatorReceivedCoinsEvt)
@@ -119,12 +120,11 @@ func (sf *WrapperMsgWithdrawDelegatorReward) HandleMsg(msgType string, msg stdTy
 	//This may be able to be optimized by doing one or the other
 	coin, err := stdTypes.ParseCoinNormalized(coinsReceived)
 	if err != nil {
-		coins, err := stdTypes.ParseCoinsNormalized(coinsReceived)
+		sf.MultiCoinsReceived, err = stdTypes.ParseCoinsNormalized(coinsReceived)
 		if err != nil {
 			config.Log.Error("Error parsing coins normalized", zap.Error(err))
 			return err
 		}
-		sf.MultiCoinsReceived = coins
 	} else {
 		sf.CoinReceived = coin
 	}

--- a/cosmos/modules/distribution/types.go
+++ b/cosmos/modules/distribution/types.go
@@ -2,17 +2,16 @@ package distribution
 
 import (
 	"fmt"
+
 	"github.com/DefiantLabs/cosmos-tax-cli-private/config"
+	parsingTypes "github.com/DefiantLabs/cosmos-tax-cli-private/cosmos/modules"
 	txModule "github.com/DefiantLabs/cosmos-tax-cli-private/cosmos/modules/tx"
 	"github.com/DefiantLabs/cosmos-tax-cli-private/util"
-	"go.uber.org/zap"
-
-	parsingTypes "github.com/DefiantLabs/cosmos-tax-cli-private/cosmos/modules"
-
 	stdTypes "github.com/cosmos/cosmos-sdk/types"
+	bankTypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	distTypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 
-	bankTypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"go.uber.org/zap"
 )
 
 const (
@@ -40,7 +39,7 @@ type WrapperMsgWithdrawValidatorCommission struct {
 type WrapperMsgWithdrawDelegatorReward struct {
 	txModule.Message
 	CosmosMsgWithdrawDelegatorReward *distTypes.MsgWithdrawDelegatorReward
-	CoinsReceived                    stdTypes.Coin
+	CoinReceived                     stdTypes.Coin
 	MultiCoinsReceived               stdTypes.Coins
 }
 
@@ -62,7 +61,7 @@ func (sf *WrapperMsgFundCommunityPool) HandleMsg(msgType string, msg stdTypes.Ms
 	return nil
 }
 
-// HandleMsg: Handle type checking for MsgWithdrawDelegatorReward
+// HandleMsg: Handle type checking for WrapperMsgWithdrawValidatorCommission
 func (sf *WrapperMsgWithdrawValidatorCommission) HandleMsg(msgType string, msg stdTypes.Msg, log *txModule.LogMessage) error {
 	sf.Type = msgType
 	sf.CosmosMsgWithdrawValidatorCommission = msg.(*distTypes.MsgWithdrawValidatorCommission)
@@ -84,13 +83,12 @@ func (sf *WrapperMsgWithdrawValidatorCommission) HandleMsg(msgType string, msg s
 
 	coin, err := stdTypes.ParseCoinNormalized(coinsReceived)
 	if err != nil {
-		coins, err := stdTypes.ParseCoinsNormalized(coinsReceived)
+		sf.MultiCoinsReceived, err = stdTypes.ParseCoinsNormalized(coinsReceived)
 		if err != nil {
 			fmt.Println("Error parsing coins normalized")
 			fmt.Println(err)
 			return err
 		}
-		sf.MultiCoinsReceived = coins
 	} else {
 		sf.CoinsReceived = coin
 	}
@@ -110,13 +108,12 @@ func (sf *WrapperMsgWithdrawDelegatorReward) HandleMsg(msgType string, msg stdTy
 	}
 
 	//The attribute in the log message that shows you the delegator withdrawal address and amount received
-	delegatorReceivedCoinsEvt := txModule.GetEventWithType(distTypes.EventTypeWithdrawRewards, log)
+	delegatorReceivedCoinsEvt := txModule.GetEventWithType(bankTypes.EventTypeTransfer, log)
 	if delegatorReceivedCoinsEvt == nil {
-		config.Log.Error("Failed to get delegatorReceivedCoinsEvt from msg")
 		return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
 	}
 
-	delegatorAddress := txModule.GetValueForAttribute(bankTypes.AttributeKeyReceiver, delegatorReceivedCoinsEvt)
+	delegatorAddress := txModule.GetValueForAttribute(bankTypes.AttributeKeyRecipient, delegatorReceivedCoinsEvt)
 	coinsReceived := txModule.GetValueForAttribute("amount", delegatorReceivedCoinsEvt)
 
 	//This may be able to be optimized by doing one or the other
@@ -129,7 +126,7 @@ func (sf *WrapperMsgWithdrawDelegatorReward) HandleMsg(msgType string, msg stdTy
 		}
 		sf.MultiCoinsReceived = coins
 	} else {
-		sf.CoinsReceived = coin
+		sf.CoinReceived = coin
 	}
 	if sf.CosmosMsgWithdrawDelegatorReward.DelegatorAddress != delegatorAddress {
 		return fmt.Errorf("transaction delegator address %s does not match log event '%s' delegator address %s",
@@ -177,7 +174,7 @@ func (sf *WrapperMsgWithdrawValidatorCommission) ParseRelevantData() []parsingTy
 }
 
 func (sf *WrapperMsgWithdrawDelegatorReward) ParseRelevantData() []parsingTypes.MessageRelevantInformation {
-	if sf.CoinsReceived.IsNil() {
+	if sf.CoinReceived.IsNil() {
 		relevantData := make([]parsingTypes.MessageRelevantInformation, len(sf.MultiCoinsReceived))
 		for i, v := range sf.MultiCoinsReceived {
 			relevantData[i] = parsingTypes.MessageRelevantInformation{
@@ -191,8 +188,8 @@ func (sf *WrapperMsgWithdrawDelegatorReward) ParseRelevantData() []parsingTypes.
 	}
 	relevantData := make([]parsingTypes.MessageRelevantInformation, 1)
 	relevantData[0] = parsingTypes.MessageRelevantInformation{
-		AmountReceived:       sf.CoinsReceived.Amount.BigInt(),
-		DenominationReceived: sf.CoinsReceived.Denom,
+		AmountReceived:       sf.CoinReceived.Amount.BigInt(),
+		DenominationReceived: sf.CoinReceived.Denom,
 		SenderAddress:        "",
 		ReceiverAddress:      sf.CosmosMsgWithdrawDelegatorReward.DelegatorAddress,
 	}
@@ -201,8 +198,8 @@ func (sf *WrapperMsgWithdrawDelegatorReward) ParseRelevantData() []parsingTypes.
 
 func (sf *WrapperMsgWithdrawDelegatorReward) String() string {
 	var coinsReceivedString string
-	if !sf.CoinsReceived.IsNil() {
-		coinsReceivedString = sf.CoinsReceived.String()
+	if !sf.CoinReceived.IsNil() {
+		coinsReceivedString = sf.CoinReceived.String()
 	} else {
 		coinsReceivedString = sf.MultiCoinsReceived.String()
 	}

--- a/cosmos/modules/distribution/types.go
+++ b/cosmos/modules/distribution/types.go
@@ -2,12 +2,10 @@ package distribution
 
 import (
 	"fmt"
-	"github.com/DefiantLabs/cosmos-tax-cli-private/util"
-
 	"github.com/DefiantLabs/cosmos-tax-cli-private/config"
-	"go.uber.org/zap"
-
 	txModule "github.com/DefiantLabs/cosmos-tax-cli-private/cosmos/modules/tx"
+	"github.com/DefiantLabs/cosmos-tax-cli-private/util"
+	"go.uber.org/zap"
 
 	parsingTypes "github.com/DefiantLabs/cosmos-tax-cli-private/cosmos/modules"
 
@@ -76,7 +74,7 @@ func (sf *WrapperMsgWithdrawValidatorCommission) HandleMsg(msgType string, msg s
 	}
 
 	//The attribute in the log message that shows you the delegator withdrawal address and amount received
-	delegatorReceivedCoinsEvt := txModule.GetEventWithType(bankTypes.EventTypeCoinReceived, log)
+	delegatorReceivedCoinsEvt := txModule.GetEventWithType(distTypes.EventTypeWithdrawCommission, log)
 	if delegatorReceivedCoinsEvt == nil {
 		return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
 	}
@@ -112,7 +110,7 @@ func (sf *WrapperMsgWithdrawDelegatorReward) HandleMsg(msgType string, msg stdTy
 	}
 
 	//The attribute in the log message that shows you the delegator withdrawal address and amount received
-	delegatorReceivedCoinsEvt := txModule.GetEventWithType(bankTypes.EventTypeCoinReceived, log)
+	delegatorReceivedCoinsEvt := txModule.GetEventWithType(distTypes.EventTypeWithdrawRewards, log)
 	if delegatorReceivedCoinsEvt == nil {
 		config.Log.Error("Failed to get delegatorReceivedCoinsEvt from msg")
 		return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}

--- a/cosmos/modules/ibc/types.go
+++ b/cosmos/modules/ibc/types.go
@@ -3,6 +3,7 @@ package ibc
 import (
 	"fmt"
 	parsingTypes "github.com/DefiantLabs/cosmos-tax-cli-private/cosmos/modules"
+	"github.com/DefiantLabs/cosmos-tax-cli-private/util"
 
 	types "github.com/DefiantLabs/cosmos-tax-cli-private/cosmos/modules/ibc/types"
 	txModule "github.com/DefiantLabs/cosmos-tax-cli-private/cosmos/modules/tx"
@@ -29,7 +30,7 @@ func (sf *WrapperMsgTransfer) HandleMsg(msgType string, msg stdTypes.Msg, log *t
 	//Confirm that the action listed in the message log matches the Message type
 	validLog := txModule.IsMessageActionEquals(sf.GetType(), log)
 	if !validLog {
-		return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
+		return util.ReturnInvalidLog(msgType, log)
 	}
 
 	//Funds sent and sender address are pulled from the parsed Cosmos Msg

--- a/cosmos/modules/staking/types.go
+++ b/cosmos/modules/staking/types.go
@@ -75,7 +75,7 @@ func (sf *WrapperMsgUndelegate) HandleMsg(msgType string, msg stdTypes.Msg, log 
 	sf.CosmosMsgUndelegate = msg.(*stakeTypes.MsgUndelegate)
 
 	//Confirm that the action listed in the message log matches the Message type
-	validLog := txModule.IsMessageActionEquals(sf.GetType(), log)
+	validLog := txModule.IsMessageActionEquals("begin_unbonding", log)
 	if !validLog {
 		return util.ReturnInvalidLog(msgType, log)
 	}

--- a/cosmos/modules/staking/types.go
+++ b/cosmos/modules/staking/types.go
@@ -2,6 +2,7 @@ package staking
 
 import (
 	"fmt"
+	"github.com/DefiantLabs/cosmos-tax-cli-private/util"
 	"strings"
 
 	txModule "github.com/DefiantLabs/cosmos-tax-cli-private/cosmos/modules/tx"
@@ -47,7 +48,7 @@ func (sf *WrapperMsgDelegate) HandleMsg(msgType string, msg stdTypes.Msg, log *t
 	//Confirm that the action listed in the message log matches the Message type
 	validLog := txModule.IsMessageActionEquals(sf.GetType(), log)
 	if !validLog {
-		return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
+		return util.ReturnInvalidLog(msgType, log)
 	}
 
 	//The attribute in the log message that shows you the delegator rewards auto-received
@@ -76,7 +77,7 @@ func (sf *WrapperMsgUndelegate) HandleMsg(msgType string, msg stdTypes.Msg, log 
 	//Confirm that the action listed in the message log matches the Message type
 	validLog := txModule.IsMessageActionEquals(sf.GetType(), log)
 	if !validLog {
-		return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
+		return util.ReturnInvalidLog(msgType, log)
 	}
 
 	//The attribute in the log message that shows you the delegator rewards auto-received
@@ -122,7 +123,7 @@ func (sf *WrapperMsgBeginRedelegate) HandleMsg(msgType string, msg stdTypes.Msg,
 	//Confirm that the action listed in the message log matches the Message type
 	validLog := txModule.IsMessageActionEquals(sf.GetType(), log)
 	if !validLog {
-		return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
+		return util.ReturnInvalidLog(msgType, log)
 	}
 
 	//The attribute in the log message that shows you the delegator rewards auto-received

--- a/cosmos/modules/tx/logic.go
+++ b/cosmos/modules/tx/logic.go
@@ -1,5 +1,11 @@
 package tx
 
+import (
+	"fmt"
+	"strings"
+	"unicode"
+)
+
 func GetMessageLogForIndex(logs []LogMessage, index int) *LogMessage {
 	for _, log := range logs {
 		if log.MessageIndex == index {
@@ -57,15 +63,29 @@ func GetLastValueForAttribute(key string, evt *LogMessageEvent) string {
 
 func IsMessageActionEquals(messageType string, msg *LogMessage) bool {
 	logEvent := GetEventWithType("message", msg)
+	logFormattedMsgType := getLogFmtMsgType(messageType)
 	if logEvent == nil {
 		return false
 	}
 
 	for _, attr := range logEvent.Attributes {
 		if attr.Key == "action" {
-			return attr.Value == messageType
+			return attr.Value == logFormattedMsgType
 		}
 	}
 
 	return false
+}
+
+func getLogFmtMsgType(msg string) (output string) {
+	msgSuffix := strings.Split(msg, ".Msg")[1]
+	for i, char := range msgSuffix {
+		if unicode.IsUpper(char) {
+			if i != 0 {
+				output = fmt.Sprintf("%v_", output)
+			}
+		}
+		output = fmt.Sprintf("%v%v", output, string(unicode.ToLower(char)))
+	}
+	return
 }

--- a/cosmos/modules/tx/logic.go
+++ b/cosmos/modules/tx/logic.go
@@ -1,11 +1,5 @@
 package tx
 
-import (
-	"fmt"
-	"strings"
-	"unicode"
-)
-
 func GetMessageLogForIndex(logs []LogMessage, index int) *LogMessage {
 	for _, log := range logs {
 		if log.MessageIndex == index {
@@ -63,29 +57,15 @@ func GetLastValueForAttribute(key string, evt *LogMessageEvent) string {
 
 func IsMessageActionEquals(messageType string, msg *LogMessage) bool {
 	logEvent := GetEventWithType("message", msg)
-	logFormattedMsgType := getLogFmtMsgType(messageType)
 	if logEvent == nil {
 		return false
 	}
 
 	for _, attr := range logEvent.Attributes {
 		if attr.Key == "action" {
-			return attr.Value == logFormattedMsgType
+			return attr.Value == messageType
 		}
 	}
 
 	return false
-}
-
-func getLogFmtMsgType(msg string) (output string) {
-	msgSuffix := strings.Split(msg, ".Msg")[1]
-	for i, char := range msgSuffix {
-		if unicode.IsUpper(char) {
-			if i != 0 {
-				output = fmt.Sprintf("%v_", output)
-			}
-		}
-		output = fmt.Sprintf("%v%v", output, string(unicode.ToLower(char)))
-	}
-	return
 }

--- a/cosmos/modules/tx/logic.go
+++ b/cosmos/modules/tx/logic.go
@@ -40,6 +40,25 @@ func GetValueForAttribute(key string, evt *LogMessageEvent) string {
 	return ""
 }
 
+// Get the Nth value for the given key (starting at 1)
+func GetNthValueForAttribute(key string, n int, evt *LogMessageEvent) string {
+	if evt == nil || evt.Attributes == nil {
+		return ""
+	}
+	var count int
+	for i := 0; i < len(evt.Attributes); i++ {
+		attr := evt.Attributes[i]
+		if attr.Key == key {
+			count++
+			if count == n {
+				return attr.Value
+			}
+		}
+	}
+
+	return ""
+}
+
 func GetLastValueForAttribute(key string, evt *LogMessageEvent) string {
 	if evt == nil || evt.Attributes == nil {
 		return ""

--- a/cosmos/modules/tx/types.go
+++ b/cosmos/modules/tx/types.go
@@ -1,7 +1,10 @@
 package tx
 
 import (
+	"fmt"
 	parsingTypes "github.com/DefiantLabs/cosmos-tax-cli-private/cosmos/modules"
+	"strings"
+	"unicode"
 
 	cosmTx "github.com/cosmos/cosmos-sdk/types/tx"
 
@@ -145,7 +148,18 @@ type Message struct {
 }
 
 func (sf *Message) GetType() string {
-	return sf.Type
+	var output string
+	msgSuffix := strings.Split(sf.Type, ".Msg")[1]
+	for i, char := range msgSuffix {
+		if unicode.IsUpper(char) {
+			if i != 0 {
+				output = fmt.Sprintf("%v_", output)
+			}
+		}
+		output = fmt.Sprintf("%v%v", output, string(unicode.ToLower(char)))
+	}
+
+	return output
 }
 
 // CosmosMessage represents a Cosmos blockchain Message (part of a transaction).

--- a/osmosis/modules/gamm/types.go
+++ b/osmosis/modules/gamm/types.go
@@ -2,6 +2,7 @@ package gamm
 
 import (
 	"fmt"
+	"github.com/DefiantLabs/cosmos-tax-cli-private/util"
 	"math/big"
 	"strings"
 	"time"
@@ -203,18 +204,20 @@ func (sf *WrapperMsgSwapExactAmountIn) HandleMsg(msgType string, msg sdk.Msg, lo
 	//Confirm that the action listed in the message log matches the Message type
 	validLog := txModule.IsMessageActionEquals(sf.GetType(), log)
 	if !validLog {
-		return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
+		return util.ReturnInvalidLog(msgType, log)
 	}
 
 	//The attribute in the log message that shows you the tokens swapped
 	tokensSwappedEvt := txModule.GetEventWithType(gammTypes.TypeEvtTokenSwapped, log)
 	if tokensSwappedEvt == nil {
+		fmt.Println("Error getting event type.")
 		return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
 	}
 
 	//Address of whoever initiated the swap. Will be both sender/receiver.
 	senderReceiver := txModule.GetValueForAttribute("sender", tokensSwappedEvt)
 	if senderReceiver == "" {
+		fmt.Println("Error getting sender.")
 		return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
 	}
 	sf.Address = senderReceiver
@@ -223,6 +226,7 @@ func (sf *WrapperMsgSwapExactAmountIn) HandleMsg(msgType string, msg sdk.Msg, lo
 	tokenInStr := txModule.GetValueForAttribute(gammTypes.AttributeKeyTokensIn, tokensSwappedEvt)
 	tokenIn, err := sdk.ParseCoinNormalized(tokenInStr)
 	if err != nil {
+		fmt.Println("Error parsing coins in. Err: ", err)
 		return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
 	}
 	sf.TokenIn = tokenIn
@@ -231,6 +235,7 @@ func (sf *WrapperMsgSwapExactAmountIn) HandleMsg(msgType string, msg sdk.Msg, lo
 	tokenOutStr := txModule.GetLastValueForAttribute(gammTypes.AttributeKeyTokensOut, tokensSwappedEvt)
 	tokenOut, err := sdk.ParseCoinNormalized(tokenOutStr)
 	if err != nil {
+		fmt.Println("Error parsing coins out. Err: ", err)
 		return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
 	}
 	sf.TokenOut = tokenOut
@@ -245,7 +250,7 @@ func (sf *WrapperMsgSwapExactAmountOut) HandleMsg(msgType string, msg sdk.Msg, l
 	//Confirm that the action listed in the message log matches the Message type
 	validLog := txModule.IsMessageActionEquals(sf.GetType(), log)
 	if !validLog {
-		return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
+		return util.ReturnInvalidLog(msgType, log)
 	}
 
 	//The attribute in the log message that shows you the tokens swapped
@@ -287,7 +292,7 @@ func (sf *WrapperMsgJoinSwapExternAmountIn) HandleMsg(msgType string, msg sdk.Ms
 	//Confirm that the action listed in the message log matches the Message type
 	validLog := txModule.IsMessageActionEquals(sf.GetType(), log)
 	if !validLog {
-		return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
+		return util.ReturnInvalidLog(msgType, log)
 	}
 
 	//The attribute in the log message that shows you the received GAMM tokens from the pool
@@ -330,7 +335,7 @@ func (sf *WrapperMsgJoinSwapShareAmountOut) HandleMsg(msgType string, msg sdk.Ms
 	//Confirm that the action listed in the message log matches the Message type
 	validLog := txModule.IsMessageActionEquals(sf.GetType(), log)
 	if !validLog {
-		return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
+		return util.ReturnInvalidLog(msgType, log)
 	}
 
 	//The attribute in the log message that shows you the received GAMM tokens from the pool
@@ -379,7 +384,7 @@ func (sf *WrapperMsgJoinPool) HandleMsg(msgType string, msg sdk.Msg, log *txModu
 	//Confirm that the action listed in the message log matches the Message type
 	validLog := txModule.IsMessageActionEquals(sf.GetType(), log)
 	if !validLog {
-		return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
+		return util.ReturnInvalidLog(msgType, log)
 	}
 
 	// //The attribute in the log message that shows you the received GAMM tokens from the pool
@@ -430,7 +435,7 @@ func (sf *WrapperMsgExitSwapShareAmountIn) HandleMsg(msgType string, msg sdk.Msg
 	//Confirm that the action listed in the message log matches the Message type
 	validLog := txModule.IsMessageActionEquals(sf.GetType(), log)
 	if !validLog {
-		return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
+		return util.ReturnInvalidLog(msgType, log)
 	}
 
 	//The attribute in the log message that shows you the burned GAMM tokens sent to the pool
@@ -480,7 +485,7 @@ func (sf *WrapperMsgExitSwapExternAmountOut) HandleMsg(msgType string, msg sdk.M
 	//Confirm that the action listed in the message log matches the Message type
 	validLog := txModule.IsMessageActionEquals(sf.GetType(), log)
 	if !validLog {
-		return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
+		return util.ReturnInvalidLog(msgType, log)
 	}
 
 	//The attribute in the log message that shows you the burned GAMM tokens sent to the pool
@@ -530,7 +535,7 @@ func (sf *WrapperMsgExitPool) HandleMsg(msgType string, msg sdk.Msg, log *txModu
 	//Confirm that the action listed in the message log matches the Message type
 	validLog := txModule.IsMessageActionEquals(sf.GetType(), log)
 	if !validLog {
-		return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
+		return util.ReturnInvalidLog(msgType, log)
 	}
 
 	//The attribute in the log message that shows you the sent GAMM tokens during the exit

--- a/osmosis/modules/gamm/types.go
+++ b/osmosis/modules/gamm/types.go
@@ -304,6 +304,10 @@ func (sf *WrapperMsgJoinSwapExternAmountIn) HandleMsg(msgType string, msg sdk.Ms
 
 	// This gets the amount of GAMM tokens received
 	gammTokenInStr := txModule.GetValueForAttribute("amount", coinbaseEvt)
+	if !strings.Contains(gammTokenInStr, "gamm") {
+		fmt.Println("Gamm token in string must contain gamm")
+		return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
+	}
 	gammTokenIn, err := sdk.ParseCoinNormalized(gammTokenInStr)
 	if err != nil {
 		return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
@@ -347,6 +351,10 @@ func (sf *WrapperMsgJoinSwapShareAmountOut) HandleMsg(msgType string, msg sdk.Ms
 
 	// This gets the amount of GAMM tokens received
 	gammTokenInStr := txModule.GetValueForAttribute("amount", coinbaseEvt)
+	if !strings.Contains(gammTokenInStr, "gamm") {
+		fmt.Println("Gamm token in string must contain gamm")
+		return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
+	}
 	gammTokenIn, err := sdk.ParseCoinNormalized(gammTokenInStr)
 	if err != nil {
 		return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
@@ -397,8 +405,10 @@ func (sf *WrapperMsgJoinPool) HandleMsg(msgType string, msg sdk.Msg, log *txModu
 	//This gets the amount of GAMM tokens received
 	gammTokenOutStr := txModule.GetLastValueForAttribute("amount", transferEvt)
 	if !strings.Contains(gammTokenOutStr, "gamm") {
+		fmt.Println("Gamm token out string must contain gamm")
 		return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
 	}
+
 	gammTokenOut, err := sdk.ParseCoinNormalized(gammTokenOutStr)
 	if err != nil {
 		return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
@@ -450,6 +460,10 @@ func (sf *WrapperMsgExitSwapShareAmountIn) HandleMsg(msgType string, msg sdk.Msg
 
 	// This gets the amount of GAMM exited with
 	gammTokenInStr := txModule.GetValueForAttribute("amount", burnEvt)
+	if !strings.Contains(gammTokenInStr, "gamm") {
+		fmt.Println("Gamm token in string must contain gamm")
+		return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
+	}
 	gammTokenIn, err := sdk.ParseCoinNormalized(gammTokenInStr)
 	if err != nil {
 		return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
@@ -500,6 +514,10 @@ func (sf *WrapperMsgExitSwapExternAmountOut) HandleMsg(msgType string, msg sdk.M
 
 	// This gets the amount of GAMM exited with
 	gammTokenInStr := txModule.GetValueForAttribute("amount", burnEvt)
+	if !strings.Contains(gammTokenInStr, "gamm") {
+		fmt.Println("Gamm token in string must contain gamm")
+		return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
+	}
 	gammTokenIn, err := sdk.ParseCoinNormalized(gammTokenInStr)
 	if err != nil {
 		return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
@@ -551,6 +569,7 @@ func (sf *WrapperMsgExitPool) HandleMsg(msgType string, msg sdk.Msg, log *txModu
 	// This gets the amount of GAMM tokens sent
 	gammTokenOutStr := txModule.GetLastValueForAttribute("amount", transverEvt)
 	if !strings.Contains(gammTokenOutStr, "gamm") {
+		fmt.Println("Gamm token out string must contain gamm")
 		return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
 	}
 	gammTokenOut, err := sdk.ParseCoinNormalized(gammTokenOutStr)

--- a/util/utils.go
+++ b/util/utils.go
@@ -61,5 +61,6 @@ func StrNotSet(value string) bool {
 
 func ReturnInvalidLog(msgType string, log *txModule.LogMessage) error {
 	fmt.Println("Error: Log is invalid.")
+	fmt.Println(log)
 	return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
 }

--- a/util/utils.go
+++ b/util/utils.go
@@ -1,6 +1,8 @@
 package util
 
 import (
+	"fmt"
+	txModule "github.com/DefiantLabs/cosmos-tax-cli-private/cosmos/modules/tx"
 	"math/big"
 	"regexp"
 
@@ -55,4 +57,9 @@ func WalkFindStrings(data interface{}, regex *regexp.Regexp) []string {
 // StrNotSet will return true if the string value provided is empty
 func StrNotSet(value string) bool {
 	return len(value) == 0
+}
+
+func ReturnInvalidLog(msgType string, log *txModule.LogMessage) error {
+	fmt.Println("Error: Log is invalid.")
+	return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
 }


### PR DESCRIPTION
I found what appear to be a bunch of issues with how some messages were being handled.

I think this is why were are seeing most of the `{"level":"fatal","timestamp":"2022-11-06T07:07:24.038-0500","message":"Issue parsing a cosmos msg that we DO have a parser for! PLEASE INVESTIGATE"}` errors

