### PR TITLE
Handle both action formats

### DIFF
--- a/cosmos/modules/staking/types.go
+++ b/cosmos/modules/staking/types.go
@@ -75,7 +75,7 @@ func (sf *WrapperMsgUndelegate) HandleMsg(msgType string, msg stdTypes.Msg, log 
 	sf.CosmosMsgUndelegate = msg.(*stakeTypes.MsgUndelegate)
 
 	//Confirm that the action listed in the message log matches the Message type
-	validLog := txModule.IsMessageActionEquals("begin_unbonding", log)
+	validLog := txModule.IsMessageActionEquals(sf.GetType(), log)
 	if !validLog {
 		return util.ReturnInvalidLog(msgType, log)
 	}

--- a/cosmos/modules/tx/logic.go
+++ b/cosmos/modules/tx/logic.go
@@ -1,5 +1,11 @@
 package tx
 
+import (
+	"fmt"
+	"strings"
+	"unicode"
+)
+
 func GetMessageLogForIndex(logs []LogMessage, index int) *LogMessage {
 	for _, log := range logs {
 		if log.MessageIndex == index {
@@ -74,17 +80,45 @@ func GetLastValueForAttribute(key string, evt *LogMessageEvent) string {
 	return ""
 }
 
-func IsMessageActionEquals(messageType string, msg *LogMessage) bool {
+func IsMessageActionEquals(msgType string, msg *LogMessage) bool {
 	logEvent := GetEventWithType("message", msg)
+	altMsgType := getAltMsgType(msgType)
 	if logEvent == nil {
 		return false
 	}
 
 	for _, attr := range logEvent.Attributes {
 		if attr.Key == "action" {
-			return attr.Value == messageType
+			if attr.Value == msgType || attr.Value == altMsgType {
+				return true
+			}
 		}
 	}
 
 	return false
+}
+
+var altMsgMap = map[string]string{
+	"/cosmos.staking.v1beta1.MsgUndelegate": "begin_unbonding",
+}
+
+func getAltMsgType(msgType string) string {
+	if altMsg, ok := altMsgMap[msgType]; ok {
+		return altMsg
+	}
+
+	var output string
+	msgParts := strings.Split(msgType, ".Msg")
+	if len(msgParts) == 2 {
+		msgSuffix := msgParts[1]
+		for i, char := range msgSuffix {
+			if unicode.IsUpper(char) {
+				if i != 0 {
+					output = fmt.Sprintf("%v_", output)
+				}
+			}
+			output = fmt.Sprintf("%v%v", output, string(unicode.ToLower(char)))
+		}
+	}
+	return output
 }

--- a/cosmos/modules/tx/types.go
+++ b/cosmos/modules/tx/types.go
@@ -1,11 +1,7 @@
 package tx
 
 import (
-	"fmt"
 	parsingTypes "github.com/DefiantLabs/cosmos-tax-cli-private/cosmos/modules"
-	"strings"
-	"unicode"
-
 	cosmTx "github.com/cosmos/cosmos-sdk/types/tx"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -148,18 +144,7 @@ type Message struct {
 }
 
 func (sf *Message) GetType() string {
-	var output string
-	msgSuffix := strings.Split(sf.Type, ".Msg")[1]
-	for i, char := range msgSuffix {
-		if unicode.IsUpper(char) {
-			if i != 0 {
-				output = fmt.Sprintf("%v_", output)
-			}
-		}
-		output = fmt.Sprintf("%v%v", output, string(unicode.ToLower(char)))
-	}
-
-	return output
+	return sf.Type
 }
 
 // CosmosMessage represents a Cosmos blockchain Message (part of a transaction).


### PR DESCRIPTION
In some older blocks, the message actions have one format, in newer blocks they have a different format. We need to support both...