### PR TITLE
Add explicit ignores for some msg types

### DIFF
--- a/core/tx.go
+++ b/core/tx.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+
 	"math/big"
 	"strings"
 	"time"
@@ -12,14 +13,16 @@ import (
 	parsingTypes "github.com/DefiantLabs/cosmos-tax-cli-private/cosmos/modules"
 	"github.com/DefiantLabs/cosmos-tax-cli-private/cosmos/modules/bank"
 	"github.com/DefiantLabs/cosmos-tax-cli-private/cosmos/modules/distribution"
+	"github.com/DefiantLabs/cosmos-tax-cli-private/cosmos/modules/gov"
 	"github.com/DefiantLabs/cosmos-tax-cli-private/cosmos/modules/ibc"
+	"github.com/DefiantLabs/cosmos-tax-cli-private/cosmos/modules/slashing"
 	"github.com/DefiantLabs/cosmos-tax-cli-private/cosmos/modules/staking"
 	tx "github.com/DefiantLabs/cosmos-tax-cli-private/cosmos/modules/tx"
 	txTypes "github.com/DefiantLabs/cosmos-tax-cli-private/cosmos/modules/tx"
 	dbTypes "github.com/DefiantLabs/cosmos-tax-cli-private/db"
 	"github.com/DefiantLabs/cosmos-tax-cli-private/osmosis"
 	"github.com/DefiantLabs/cosmos-tax-cli-private/osmosis/modules/gamm"
-	"github.com/DefiantLabs/cosmos-tax-cli-private/osmosis/modules/gov"
+	"github.com/DefiantLabs/cosmos-tax-cli-private/osmosis/modules/incentives"
 	"github.com/DefiantLabs/cosmos-tax-cli-private/osmosis/modules/lockup"
 	"github.com/DefiantLabs/cosmos-tax-cli-private/util"
 
@@ -45,13 +48,28 @@ var messageTypeHandler = map[string]func() txTypes.CosmosMessage{
 }
 
 var messageTypeIgnorer = map[string]interface{}{
-	lockup.MsgBeginUnlocking: nil,
-	lockup.MsgLockTokens:     nil,
-	gov.MsgVote:              nil,
-	ibc.MsgUpdateClient:      nil,
-	ibc.MsgAcknowledgement:   nil,
-	ibc.MsgRecvPacket:        nil,
-	ibc.MsgTimeout:           nil,
+	distribution.MsgSetWithdrawAddress: nil,
+	gov.MsgVote:                        nil,
+	ibc.MsgUpdateClient:                nil,
+	ibc.MsgAcknowledgement:             nil,
+	ibc.MsgRecvPacket:                  nil,
+	ibc.MsgTimeout:                     nil,
+	ibc.MsgCreateClient:                nil,
+	ibc.MsgConnectionOpenTry:           nil,
+	ibc.MsgConnectionOpenConfirm:       nil,
+	ibc.MsgChannelOpenTry:              nil,
+	ibc.MsgChannelOpenConfirm:          nil,
+	ibc.MsgConnectionOpenInit:          nil,
+	ibc.MsgConnectionOpenAck:           nil,
+	ibc.MsgChannelOpenInit:             nil,
+	ibc.MsgChannelOpenAck:              nil,
+	incentives.MsgCreateGauge:          nil,
+	incentives.MsgAddToGauge:           nil,
+	lockup.MsgBeginUnlocking:           nil,
+	lockup.MsgLockTokens:               nil,
+	slashing.MsgUnjail:                 nil,
+	staking.MsgCreateValidator:         nil,
+	staking.MsgEditValidator:           nil,
 }
 
 // Merge the chain specific message type handlers into the core message type handler map

--- a/core/tx.go
+++ b/core/tx.go
@@ -71,6 +71,7 @@ var messageTypeIgnorer = map[string]interface{}{
 	lockup.MsgBeginUnlocking:           nil,
 	lockup.MsgLockTokens:               nil,
 	slashing.MsgUnjail:                 nil,
+	slashing.MsgUpdateParams:           nil,
 	staking.MsgCreateValidator:         nil,
 	staking.MsgEditValidator:           nil,
 }

--- a/core/tx.go
+++ b/core/tx.go
@@ -4,13 +4,13 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-
 	"math/big"
 	"strings"
 	"time"
 
 	"github.com/DefiantLabs/cosmos-tax-cli-private/config"
 	parsingTypes "github.com/DefiantLabs/cosmos-tax-cli-private/cosmos/modules"
+	"github.com/DefiantLabs/cosmos-tax-cli-private/cosmos/modules/authz"
 	"github.com/DefiantLabs/cosmos-tax-cli-private/cosmos/modules/bank"
 	"github.com/DefiantLabs/cosmos-tax-cli-private/cosmos/modules/distribution"
 	"github.com/DefiantLabs/cosmos-tax-cli-private/cosmos/modules/gov"
@@ -48,6 +48,9 @@ var messageTypeHandler = map[string]func() txTypes.CosmosMessage{
 }
 
 var messageTypeIgnorer = map[string]interface{}{
+	authz.MsgExec:                      nil,
+	authz.MsgGrant:                     nil,
+	authz.MsgRevoke:                    nil,
 	distribution.MsgSetWithdrawAddress: nil,
 	gov.MsgVote:                        nil,
 	ibc.MsgUpdateClient:                nil,

--- a/cosmos/modules/authz/types.go
+++ b/cosmos/modules/authz/types.go
@@ -1,0 +1,7 @@
+package authz
+
+const (
+	MsgExec   = "/cosmos.authz.v1beta1.MsgExec"   //FIXME: Figure out how/if we want to handle these.
+	MsgGrant  = "/cosmos.authz.v1beta1.MsgGrant"  //FIXME: Figure out how/if we want to handle these.
+	MsgRevoke = "/cosmos.authz.v1beta1.MsgRevoke" //FIXME: Figure out how/if we want to handle these.
+)

--- a/cosmos/modules/authz/types.go
+++ b/cosmos/modules/authz/types.go
@@ -1,7 +1,8 @@
 package authz
 
+// Explicitly ignored messages for tx parsing purposes
 const (
-	MsgExec   = "/cosmos.authz.v1beta1.MsgExec"   //FIXME: Figure out how/if we want to handle these.
-	MsgGrant  = "/cosmos.authz.v1beta1.MsgGrant"  //FIXME: Figure out how/if we want to handle these.
-	MsgRevoke = "/cosmos.authz.v1beta1.MsgRevoke" //FIXME: Figure out how/if we want to handle these.
+	MsgExec   = "/cosmos.authz.v1beta1.MsgExec"
+	MsgGrant  = "/cosmos.authz.v1beta1.MsgGrant"
+	MsgRevoke = "/cosmos.authz.v1beta1.MsgRevoke"
 )

--- a/cosmos/modules/distribution/types.go
+++ b/cosmos/modules/distribution/types.go
@@ -18,7 +18,8 @@ const (
 	MsgFundCommunityPool           = "/cosmos.distribution.v1beta1.MsgFundCommunityPool"
 	MsgWithdrawValidatorCommission = "/cosmos.distribution.v1beta1.MsgWithdrawValidatorCommission"
 	MsgWithdrawDelegatorReward     = "/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward"
-	MsgWithdrawRewards             = "withdraw-rewards" // FIXME: this is used in 2 places and only 1 will work....
+	MsgWithdrawRewards             = "withdraw-rewards"                                   // FIXME: this is used in 2 places and only 1 will work....
+	MsgSetWithdrawAddress          = "/cosmos.distribution.v1beta1.MsgSetWithdrawAddress" // An explicitly ignored msg for tx parsing purposes
 )
 
 type WrapperMsgFundCommunityPool struct {

--- a/cosmos/modules/gov/types.go
+++ b/cosmos/modules/gov/types.go
@@ -5,4 +5,5 @@ const (
 	MsgVote           = "/cosmos.gov.v1beta1.MsgVote"
 	MsgDeposit        = "/cosmos.gov.v1beta1.MsgDeposit"        //FIXME: Figure out how/if we want to handle these.
 	MsgSubmitProposal = "/cosmos.gov.v1beta1.MsgSubmitProposal" //FIXME: Figure out how/if we want to handle these.
+	MsgVoteWeighted   = "/cosmos.gov.v1beta1.MsgVoteWeighted"   //FIXME: Figure out how/if we want to handle these.
 )

--- a/cosmos/modules/gov/types.go
+++ b/cosmos/modules/gov/types.go
@@ -1,0 +1,8 @@
+package gov
+
+// Explicitly ignored messages for tx parsing purposes
+const (
+	MsgVote           = "/cosmos.gov.v1beta1.MsgVote"
+	MsgDeposit        = "/cosmos.gov.v1beta1.MsgDeposit"        //FIXME: Figure out how/if we want to handle these.
+	MsgSubmitProposal = "/cosmos.gov.v1beta1.MsgSubmitProposal" //FIXME: Figure out how/if we want to handle these.
+)

--- a/cosmos/modules/ibc/types.go
+++ b/cosmos/modules/ibc/types.go
@@ -12,11 +12,22 @@ import (
 )
 
 const (
-	MsgTransfer        = "/ibc.applications.transfer.v1.MsgTransfer"
-	MsgUpdateClient    = "/ibc.core.client.v1.MsgUpdateClient"     // An explicitly ignored msg for tx parsing purposes
-	MsgAcknowledgement = "/ibc.core.channel.v1.MsgAcknowledgement" // An explicitly ignored msg for tx parsing purposes
-	MsgRecvPacket      = "/ibc.core.channel.v1.MsgRecvPacket"      // An explicitly ignored msg for tx parsing purposes
-	MsgTimeout         = "/ibc.core.channel.v1.MsgTimeout"         // An explicitly ignored msg for tx parsing purposes
+	MsgTransfer = "/ibc.applications.transfer.v1.MsgTransfer"
+
+	// Explicitly ignored messages for tx parsing purposes
+	MsgUpdateClient          = "/ibc.core.client.v1.MsgUpdateClient"
+	MsgAcknowledgement       = "/ibc.core.channel.v1.MsgAcknowledgement"
+	MsgRecvPacket            = "/ibc.core.channel.v1.MsgRecvPacket"
+	MsgTimeout               = "/ibc.core.channel.v1.MsgTimeout"
+	MsgCreateClient          = "/ibc.core.client.v1.MsgCreateClient"
+	MsgConnectionOpenTry     = "/ibc.core.connection.v1.MsgConnectionOpenTry"
+	MsgConnectionOpenConfirm = "/ibc.core.connection.v1.MsgConnectionOpenConfirm"
+	MsgChannelOpenTry        = "/ibc.core.channel.v1.MsgChannelOpenTry"
+	MsgChannelOpenConfirm    = "/ibc.core.channel.v1.MsgChannelOpenConfirm"
+	MsgConnectionOpenInit    = "/ibc.core.connection.v1.MsgConnectionOpenInit"
+	MsgConnectionOpenAck     = "/ibc.core.connection.v1.MsgConnectionOpenAck"
+	MsgChannelOpenInit       = "/ibc.core.channel.v1.MsgChannelOpenInit"
+	MsgChannelOpenAck        = "/ibc.core.channel.v1.MsgChannelOpenAck"
 )
 
 type WrapperMsgTransfer struct {

--- a/cosmos/modules/ibc/types.go
+++ b/cosmos/modules/ibc/types.go
@@ -15,19 +15,21 @@ const (
 	MsgTransfer = "/ibc.applications.transfer.v1.MsgTransfer"
 
 	// Explicitly ignored messages for tx parsing purposes
-	MsgUpdateClient          = "/ibc.core.client.v1.MsgUpdateClient"
-	MsgAcknowledgement       = "/ibc.core.channel.v1.MsgAcknowledgement"
-	MsgRecvPacket            = "/ibc.core.channel.v1.MsgRecvPacket"
-	MsgTimeout               = "/ibc.core.channel.v1.MsgTimeout"
-	MsgCreateClient          = "/ibc.core.client.v1.MsgCreateClient"
+	MsgAcknowledgement    = "/ibc.core.channel.v1.MsgAcknowledgement"
+	MsgChannelOpenTry     = "/ibc.core.channel.v1.MsgChannelOpenTry"
+	MsgChannelOpenConfirm = "/ibc.core.channel.v1.MsgChannelOpenConfirm"
+	MsgChannelOpenInit    = "/ibc.core.channel.v1.MsgChannelOpenInit"
+	MsgChannelOpenAck     = "/ibc.core.channel.v1.MsgChannelOpenAck"
+	MsgRecvPacket         = "/ibc.core.channel.v1.MsgRecvPacket"
+	MsgTimeout            = "/ibc.core.channel.v1.MsgTimeout"
+
 	MsgConnectionOpenTry     = "/ibc.core.connection.v1.MsgConnectionOpenTry"
 	MsgConnectionOpenConfirm = "/ibc.core.connection.v1.MsgConnectionOpenConfirm"
-	MsgChannelOpenTry        = "/ibc.core.channel.v1.MsgChannelOpenTry"
-	MsgChannelOpenConfirm    = "/ibc.core.channel.v1.MsgChannelOpenConfirm"
 	MsgConnectionOpenInit    = "/ibc.core.connection.v1.MsgConnectionOpenInit"
 	MsgConnectionOpenAck     = "/ibc.core.connection.v1.MsgConnectionOpenAck"
-	MsgChannelOpenInit       = "/ibc.core.channel.v1.MsgChannelOpenInit"
-	MsgChannelOpenAck        = "/ibc.core.channel.v1.MsgChannelOpenAck"
+
+	MsgCreateClient = "/ibc.core.client.v1.MsgCreateClient"
+	MsgUpdateClient = "/ibc.core.client.v1.MsgUpdateClient"
 )
 
 type WrapperMsgTransfer struct {

--- a/cosmos/modules/ibc/types.go
+++ b/cosmos/modules/ibc/types.go
@@ -12,7 +12,11 @@ import (
 )
 
 const (
-	MsgTransfer = "/ibc.applications.transfer.v1.MsgTransfer"
+	MsgTransfer        = "/ibc.applications.transfer.v1.MsgTransfer"
+	MsgUpdateClient    = "/ibc.core.client.v1.MsgUpdateClient"     // An explicitly ignored msg for tx parsing purposes
+	MsgAcknowledgement = "/ibc.core.channel.v1.MsgAcknowledgement" // An explicitly ignored msg for tx parsing purposes
+	MsgRecvPacket      = "/ibc.core.channel.v1.MsgRecvPacket"      // An explicitly ignored msg for tx parsing purposes
+	MsgTimeout         = "/ibc.core.channel.v1.MsgTimeout"         // An explicitly ignored msg for tx parsing purposes
 )
 
 type WrapperMsgTransfer struct {

--- a/cosmos/modules/slashing/types.go
+++ b/cosmos/modules/slashing/types.go
@@ -1,0 +1,3 @@
+package slashing
+
+const MsgUnjail = "/cosmos.slashing.v1beta1.MsgUnjail" // An explicitly ignored msg for tx parsing purposes

--- a/cosmos/modules/slashing/types.go
+++ b/cosmos/modules/slashing/types.go
@@ -1,3 +1,7 @@
 package slashing
 
-const MsgUnjail = "/cosmos.slashing.v1beta1.MsgUnjail" // An explicitly ignored msg for tx parsing purposes
+// Explicitly ignored messages for tx parsing purposes
+const (
+	MsgUnjail       = "/cosmos.slashing.v1beta1.MsgUnjail"
+	MsgUpdateParams = "/cosmos.slashing.v1beta1.MsgUpdateParams"
+)

--- a/cosmos/modules/staking/types.go
+++ b/cosmos/modules/staking/types.go
@@ -17,6 +17,8 @@ const (
 	MsgDelegate        = "/cosmos.staking.v1beta1.MsgDelegate"
 	MsgUndelegate      = "/cosmos.staking.v1beta1.MsgUndelegate"
 	MsgBeginRedelegate = "/cosmos.staking.v1beta1.MsgBeginRedelegate"
+	MsgCreateValidator = "/cosmos.staking.v1beta1.MsgCreateValidator" // An explicitly ignored msg for tx parsing purposes
+	MsgEditValidator   = "/cosmos.staking.v1beta1.MsgEditValidator"   // An explicitly ignored msg for tx parsing purposes
 )
 
 type WrapperMsgDelegate struct {

--- a/osmosis/modules/gov/types.go
+++ b/osmosis/modules/gov/types.go
@@ -1,0 +1,6 @@
+package gov
+
+// Explicitly ignored messages for tx parsing purposes
+const (
+	MsgVote = "/cosmos.gov.v1beta1.MsgVote"
+)

--- a/osmosis/modules/gov/types.go
+++ b/osmosis/modules/gov/types.go
@@ -1,6 +1,0 @@
-package gov
-
-// Explicitly ignored messages for tx parsing purposes
-const (
-	MsgVote = "/cosmos.gov.v1beta1.MsgVote"
-)

--- a/osmosis/modules/incentives/types.go
+++ b/osmosis/modules/incentives/types.go
@@ -1,0 +1,6 @@
+package incentives
+
+const (
+	MsgCreateGauge = "/osmosis.incentives.MsgCreateGauge" // An explicitly ignored msg for tx parsing purposes
+	MsgAddToGauge  = "/osmosis.incentives.MsgAddToGauge"  // An explicitly ignored msg for tx parsing purposes
+)

--- a/osmosis/modules/lockup/types.go
+++ b/osmosis/modules/lockup/types.go
@@ -1,0 +1,7 @@
+package lockup
+
+// Explicitly ignored messages for tx parsing purposes
+const (
+	MsgBeginUnlocking = "/osmosis.lockup.MsgBeginUnlocking"
+	MsgLockTokens     = "/osmosis.lockup.MsgLockTokens" // nolint:gosec
+)


### PR DESCRIPTION
Explicitly ignores message we know we don’t care about. Still not sure what to do with the gov messages (hoping to hear back from the community on discord), but in the meantime, this will make the logs a bit quieter for the **other** message. To be clear, **fees will still be processed**, this does not change how message are handled in any way, it just add missing message types and get rid of the ‘failure to parse’ message we see for some messages we explicitly don’t need to parse.