### PR TITLE
Handle fee attribution when there is no public key

### DIFF
--- a/cosmos/modules/tx/types.go
+++ b/cosmos/modules/tx/types.go
@@ -42,9 +42,9 @@ type GetTxByBlockHeightResponse struct {
 }
 
 type IndexerTx struct {
-	Body       Body `json:"body"`
-	AuthInfo   cosmTx.AuthInfo
-	Signatures []string `json:"signatures"`
+	Body     Body `json:"body"`
+	AuthInfo cosmTx.AuthInfo
+	Signers  []sdk.AccAddress // TODO: We may be able to use this in place of signer info under auth info... not 100% sure
 }
 
 type Response struct {


### PR DESCRIPTION
In some message we don't have a public key under the auth_info section to use to determine the fee payer. In this case we can determine the address from the tx signer. https://www.mintscan.io/osmosis/txs/37E642EB525855AF74B6279CE0A8FEB2A632C2EBCE8FB12DB3A10A951B80022E