### PR TITLE
check pwd for config

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -46,14 +46,23 @@ func initConfig() {
 		viper.SetConfigFile(cfgFile)
 		viper.SetConfigType("toml")
 	} else {
-		// Find home directory.
-		home, err := os.UserHomeDir()
+		// Check in current working dir
+		pwd, err := os.Getwd()
 		if err != nil {
-			log.Fatalf("Failed to find user home dir. Err: %v", err)
+			log.Fatalf("Could not determine current working dir. Err: %v", err)
 		}
-		defaultCfgLocation := fmt.Sprintf("%s/.cosmos-tax-cli-private", home)
-
-		viper.AddConfigPath(defaultCfgLocation)
+		if _, err := os.Stat(fmt.Sprintf("%v/config.toml", pwd)); err == nil {
+			cfgFile = pwd
+		} else {
+			// file not in current working dir. Check home dir instead
+			// Find home directory.
+			home, err := os.UserHomeDir()
+			if err != nil {
+				log.Fatalf("Failed to find user home dir. Err: %v", err)
+			}
+			cfgFile = fmt.Sprintf("%s/.cosmos-tax-cli-private", home)
+		}
+		viper.AddConfigPath(cfgFile)
 		viper.SetConfigType("toml")
 		viper.SetConfigName("config")
 	}
@@ -63,6 +72,8 @@ func initConfig() {
 	if err != nil {
 		log.Fatalf("Failed to read config file. Err: %v", err)
 	}
+
+	log.Println("CFG successfully read from: ", cfgFile)
 
 	// Unmarshal the config into struct
 	err = viper.Unmarshal(&conf)


### PR DESCRIPTION
When running, look for cfg in this order:
- provided path
- in the pwd
- in the user's home dir

I also added a log msg to tell you which config you loaded. now that your config could be so many places it may help save some grief in the future to confirm which config we are using.