### PR TITLE
Move chain-specific stuff out of query path

### DIFF
--- a/cmd/index.go
+++ b/cmd/index.go
@@ -54,7 +54,11 @@ func setupIndexer() *Indexer {
 		log.Fatalf("Error during application setup. Err: %v", err)
 	}
 
+	// Setup chain specific stuff
+	core.SetupAddressRegex(idxr.cfg.Lens.AccountPrefix + "(valoper)?1[a-z0-9]{38}")
+	core.SetupAddressPrefix(idxr.cfg.Lens.AccountPrefix)
 	core.ChainSpecificMessageTypeHandlerBootstrap(idxr.cfg.Lens.ChainID)
+	config.SetChainConfig(idxr.cfg.Lens.AccountPrefix)
 
 	// TODO may need to run this task in setup() so that we have a cold start functionality before the indexer starts
 	_, err = idxr.scheduler.Every(6).Hours().Do(tasks.DenomUpsertTask, idxr.cfg.Base.API, idxr.db)
@@ -67,8 +71,6 @@ func setupIndexer() *Indexer {
 	// Some chains do not have the denom metadata URL available on chain, so we do chain specific downloads instead.
 	tasks.DoChainSpecificUpsertDenoms(idxr.db, idxr.cfg.Lens.ChainID)
 	idxr.cl = config.GetLensClient(idxr.cfg.Lens)
-
-	config.SetChainConfig(idxr.cfg.Base.AddressPrefix)
 
 	// Depending on the app configuration, wait for the chain to catch up
 	chainCatchingUp, err := rpc.IsCatchingUp(idxr.cl)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/DefiantLabs/cosmos-tax-cli-private/config"
-	"github.com/DefiantLabs/cosmos-tax-cli-private/core"
 	"github.com/go-co-op/gocron"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -44,8 +43,6 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&conf.Log.Path, "log.path", "", "log path (default is $HOME/.cosmos-tax-cli-private/logs.txt")
 
 	// Base
-	rootCmd.PersistentFlags().StringVar(&conf.Base.AddressRegex, "base.addrRegex", "", "address regex")
-	rootCmd.PersistentFlags().StringVar(&conf.Base.AddressPrefix, "base.addrPrefix", "", "address prefix")
 	rootCmd.PersistentFlags().Int64Var(&conf.Base.StartBlock, "base.startBlock", 0, "block to start indexing at")
 	rootCmd.PersistentFlags().Int64Var(&conf.Base.EndBlock, "base.endBlock", -1, "block to stop indexing at (use -1 to index indefinitely")
 
@@ -147,10 +144,6 @@ func setup(cfg config.Config) (*config.Config, *gorm.DB, *gocron.Scheduler, erro
 	sqldb.SetMaxIdleConns(10)
 	sqldb.SetMaxOpenConns(100)
 	sqldb.SetConnMaxLifetime(time.Hour)
-
-	// TODO: make mapping for all chains, globally initialized
-	core.SetupAddressRegex(cfg.Base.AddressRegex)   // e.g. "juno(valoper)?1[a-z0-9]{38}"
-	core.SetupAddressPrefix(cfg.Base.AddressPrefix) // e.g. juno
 
 	scheduler := gocron.NewScheduler(time.UTC)
 

--- a/config/app_config.go
+++ b/config/app_config.go
@@ -38,12 +38,6 @@ func (conf *Config) Validate() error {
 	}
 
 	// Base Checks
-	if util.StrNotSet(conf.Base.AddressRegex) {
-		return errors.New("base addressRegex must be set")
-	}
-	if util.StrNotSet(conf.Base.AddressPrefix) {
-		return errors.New("base addressPrefix must be set")
-	}
 	if conf.Base.StartBlock == 0 { // TODO: Verify that 0 is not a valid starting block..
 		return errors.New("base startblock must be set")
 	}
@@ -130,9 +124,7 @@ type api struct {
 }
 
 type base struct {
-	AddressRegex       string
 	API                string
-	AddressPrefix      string
 	StartBlock         int64
 	EndBlock           int64
 	Throttling         float64

--- a/csv/parser.go
+++ b/csv/parser.go
@@ -34,7 +34,7 @@ func GetParser(parserKey string) parsers.Parser {
 
 func ParseForAddress(addresses []string, startDate, endDate *time.Time, pgSQL *gorm.DB, parserKey string, cfg config.Config) ([]parsers.CsvRow, []string, error) {
 	parser := GetParser(parserKey)
-	parser.InitializeParsingGroups(cfg)
+	parser.InitializeParsingGroups()
 
 	// Get data for each address
 	var headers []string

--- a/csv/parser_test.go
+++ b/csv/parser_test.go
@@ -26,7 +26,7 @@ func TestKoinlyOsmoLPParsing(t *testing.T) {
 	cfg := config.Config{}
 	cfg.Lens.ChainID = osmosis.ChainID
 	parser := GetParser(koinly.ParserKey)
-	parser.InitializeParsingGroups(cfg)
+	parser.InitializeParsingGroups()
 
 	// setup user and chain
 	targetAddress := mkAddress(t, 1)
@@ -65,7 +65,7 @@ func TestKoinlyOsmoRewardParsing(t *testing.T) {
 	cfg := config.Config{}
 	cfg.Lens.ChainID = osmosis.ChainID
 	parser := GetParser(koinly.ParserKey)
-	parser.InitializeParsingGroups(cfg)
+	parser.InitializeParsingGroups()
 
 	// setup user and chain
 	targetAddress := mkAddress(t, 1)
@@ -100,7 +100,7 @@ func TestAccointingIbcMsgTransferSelf(t *testing.T) {
 	cfg := config.Config{}
 	cfg.Lens.ChainID = osmosis.ChainID
 	parser := GetParser(accointing.ParserKey)
-	parser.InitializeParsingGroups(cfg)
+	parser.InitializeParsingGroups()
 
 	me := "osmo18zljeu4lg4jppkz75en82qr3zymfcnchwvsqgu"
 	alsoMe := "juno18zljeu4lg4jppkz75en82qr3zymfcnchs9qtej"
@@ -144,7 +144,7 @@ func TestAccointingIbcMsgTransferExternal(t *testing.T) {
 	cfg := config.Config{}
 	cfg.Lens.ChainID = osmosis.ChainID
 	parser := GetParser(accointing.ParserKey)
-	parser.InitializeParsingGroups(cfg)
+	parser.InitializeParsingGroups()
 
 	me := "osmo14mmus5h7m6vkp0pteks8wawaj4wf3sx7fy3s2r"
 	someoneElse := "juno18zljeu4lg4jppkz75en82qr3zymfcnchs9qtej"
@@ -187,7 +187,7 @@ func TestAccointingOsmoLPParsing(t *testing.T) {
 	cfg := config.Config{}
 	cfg.Lens.ChainID = osmosis.ChainID
 	parser := GetParser(accointing.ParserKey)
-	parser.InitializeParsingGroups(cfg)
+	parser.InitializeParsingGroups()
 
 	// setup user and chain
 	targetAddress := mkAddress(t, 1)
@@ -222,7 +222,7 @@ func TestAccointingOsmoRewardParsing(t *testing.T) {
 	cfg := config.Config{}
 	cfg.Lens.ChainID = osmosis.ChainID
 	parser := GetParser(accointing.ParserKey)
-	parser.InitializeParsingGroups(cfg)
+	parser.InitializeParsingGroups()
 
 	// setup user and chain
 	targetAddress := mkAddress(t, 1)

--- a/csv/parsers/accointing/accointing.go
+++ b/csv/parsers/accointing/accointing.go
@@ -14,7 +14,6 @@ import (
 	"github.com/DefiantLabs/cosmos-tax-cli-private/cosmos/modules/staking"
 	"github.com/DefiantLabs/cosmos-tax-cli-private/csv/parsers"
 	"github.com/DefiantLabs/cosmos-tax-cli-private/db"
-	"github.com/DefiantLabs/cosmos-tax-cli-private/osmosis"
 	"github.com/DefiantLabs/cosmos-tax-cli-private/osmosis/modules/gamm"
 )
 
@@ -72,10 +71,8 @@ func (p *Parser) ProcessTaxableEvent(taxableEvents []db.TaxableEvent) error {
 	return nil
 }
 
-func (p *Parser) InitializeParsingGroups(config config.Config) {
-	if config.Lens.ChainID == osmosis.ChainID {
-		p.ParsingGroups = append(p.ParsingGroups, GetOsmosisTxParsingGroups()...)
-	}
+func (p *Parser) InitializeParsingGroups() {
+	p.ParsingGroups = append(p.ParsingGroups, GetOsmosisTxParsingGroups()...)
 }
 
 func (p *Parser) GetRows(address string, startDate, endDate *time.Time) []parsers.CsvRow {

--- a/csv/parsers/koinly/koinly.go
+++ b/csv/parsers/koinly/koinly.go
@@ -14,7 +14,6 @@ import (
 	"github.com/DefiantLabs/cosmos-tax-cli-private/cosmos/modules/staking"
 	"github.com/DefiantLabs/cosmos-tax-cli-private/csv/parsers"
 	"github.com/DefiantLabs/cosmos-tax-cli-private/db"
-	"github.com/DefiantLabs/cosmos-tax-cli-private/osmosis"
 	"github.com/DefiantLabs/cosmos-tax-cli-private/osmosis/modules/gamm"
 )
 
@@ -80,10 +79,8 @@ func (p *Parser) ProcessTaxableEvent(taxableEvents []db.TaxableEvent) error {
 	return nil
 }
 
-func (p *Parser) InitializeParsingGroups(config config.Config) {
-	if config.Lens.ChainID == osmosis.ChainID {
-		p.ParsingGroups = append(p.ParsingGroups, GetOsmosisTxParsingGroups()...)
-	}
+func (p *Parser) InitializeParsingGroups() {
+	p.ParsingGroups = append(p.ParsingGroups, GetOsmosisTxParsingGroups()...)
 }
 
 func (p *Parser) GetRows(address string, startDate, endDate *time.Time) []parsers.CsvRow {

--- a/csv/parsers/types.go
+++ b/csv/parsers/types.go
@@ -3,12 +3,11 @@ package parsers
 import (
 	"time"
 
-	"github.com/DefiantLabs/cosmos-tax-cli-private/config"
 	"github.com/DefiantLabs/cosmos-tax-cli-private/db"
 )
 
 type Parser interface {
-	InitializeParsingGroups(config config.Config)
+	InitializeParsingGroups()
 	ProcessTaxableTx(address string, taxableTxs []db.TaxableTransaction) error
 	ProcessTaxableEvent(taxableEvents []db.TaxableEvent) error
 	GetHeaders() []string

--- a/rpc/rpc_test.go
+++ b/rpc/rpc_test.go
@@ -71,8 +71,8 @@ func setupRPC(t *testing.T) *gocron.Scheduler {
 	}
 	// TODO: create config values for the prefixes here
 	// Could potentially check Node info at startup and pass in ourselves?
-	core.SetupAddressRegex(testConfig.Base.AddressRegex)
-	core.SetupAddressPrefix(testConfig.Base.AddressPrefix)
+	core.SetupAddressRegex(testConfig.Lens.AccountPrefix + "(valoper)?1[a-z0-9]{38}")
+	core.SetupAddressPrefix(testConfig.Lens.AccountPrefix)
 
 	scheduler := gocron.NewScheduler(time.UTC)
 	return scheduler


### PR DESCRIPTION
It appears that the chain-specific issues were due to the cosmos sdk being configured and messing with stuff....

I'm still not 100% sure why this works, but it appears to. Still need to do a bit more testing before I feel comfortable merging this.