### PR TITLE
Fix upsert error

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -99,7 +99,9 @@ func IndexNewBlock(db *gorm.DB, blockHeight int64, blockTime time.Time, txs []Tx
 
 		// block.BlockchainID = block.Chain.ID
 
-		if err := dbTransaction.Where(&block).FirstOrCreate(&block).Error; err != nil {
+		if err := dbTransaction.
+			Where(Block{Height: block.Height, BlockchainID: block.BlockchainID}).
+			FirstOrCreate(&block).Error; err != nil {
 			config.Log.Error("Error getting/creating block DB object.", err)
 			return err
 		}

--- a/db/models.go
+++ b/db/models.go
@@ -29,7 +29,7 @@ type Chain struct {
 
 type Tx struct {
 	ID              uint
-	Hash            string
+	Hash            string `gorm:"uniqueIndex"`
 	Code            uint32
 	BlockID         uint
 	Block           Block


### PR DESCRIPTION
When doing an upsert of a block, be specific about what fields we care about.
We care only about block height and chain ID. If they match, it is the same block.