### PR TITLE
If dividing, use denom unit's name

### DIFF
--- a/db/denoms.go
+++ b/db/denoms.go
@@ -96,8 +96,8 @@ func ConvertUnits(amount *big.Int, denom Denom) (*big.Float, string, error) {
 	power := math.Pow(10, float64(highestDenomUnit.Exponent-denomUnit.Exponent))
 	convertedAmount := new(big.Float).SetInt(amount)
 	dividedAmount := new(big.Float).Quo(convertedAmount, new(big.Float).SetFloat64(power))
-	if symbol == "UNKNOWN" {
-		symbol = denom.Base
+	if symbol == "UNKNOWN" || symbol == "" {
+		symbol = highestDenomUnit.Name
 	}
 	return dividedAmount, symbol, nil
 }

--- a/tasks/denoms.go
+++ b/tasks/denoms.go
@@ -112,6 +112,13 @@ func DenomUpsertTask(apiHost string, db *gorm.DB) {
 
 	var denoms []dbTypes.DenomDBWrapper = make([]dbTypes.DenomDBWrapper, len(denomsMetadata.Metadatas))
 	for i, denom := range denomsMetadata.Metadatas {
+		if denom.Name == "" {
+			denom.Name = "UNKNOWN"
+		}
+		if denom.Symbol == "" {
+			denom.Symbol = "UNKNOWN"
+		}
+
 		denoms[i].Denom = dbTypes.Denom{Base: denom.Base, Name: denom.Name, Symbol: denom.Symbol}
 
 		denoms[i].DenomUnits = make([]dbTypes.DenomUnitDBWrapper, len(denom.DenomUnits))


### PR DESCRIPTION
There is a bug where if we convert units but don't have a symbol, we end up using the symbol of the base denom (which is incorrect since we did the division) 