### PR TITLE
#315 missing parsers msgsubmitproposal

### DIFF
--- a/csv/parsers/cointracker/cointracker.go
+++ b/csv/parsers/cointracker/cointracker.go
@@ -8,6 +8,7 @@ import (
 	"github.com/DefiantLabs/cosmos-tax-cli/config"
 	"github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules/bank"
 	"github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules/distribution"
+	"github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules/gov"
 	"github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules/ibc"
 	"github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules/staking"
 	"github.com/DefiantLabs/cosmos-tax-cli/csv/parsers"
@@ -229,6 +230,8 @@ func ParseTx(address string, events []db.TaxableTransaction) (rows []parsers.Csv
 			rows = append(rows, ParseMsgWithdrawDelegatorReward(address, event))
 		case staking.MsgBeginRedelegate:
 			rows = append(rows, ParseMsgWithdrawDelegatorReward(address, event))
+		case gov.MsgSubmitProposal:
+			rows = append(rows, ParseMsgSubmitProposal(address, event))
 		case gamm.MsgSwapExactAmountIn:
 			rows = append(rows, ParseMsgSwapExactAmountIn(event))
 		case gamm.MsgSwapExactAmountOut:
@@ -319,6 +322,15 @@ func ParseMsgTransfer(address string, event db.TaxableTransaction) Row {
 	err := row.ParseBasic(address, event)
 	if err != nil {
 		config.Log.Fatal("Error with ParseMsgTransfer.", err)
+	}
+	return *row
+}
+
+func ParseMsgSubmitProposal(address string, event db.TaxableTransaction) Row {
+	row := &Row{}
+	err := row.ParseBasic(address, event)
+	if err != nil {
+		config.Log.Fatal("Error with ParseMsgSubmitProposal.", err)
 	}
 	return *row
 }

--- a/csv/parsers/koinly/koinly.go
+++ b/csv/parsers/koinly/koinly.go
@@ -9,6 +9,7 @@ import (
 	"github.com/DefiantLabs/cosmos-tax-cli/config"
 	"github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules/bank"
 	"github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules/distribution"
+	"github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules/gov"
 	"github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules/ibc"
 	"github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules/staking"
 	"github.com/DefiantLabs/cosmos-tax-cli/csv/parsers"
@@ -269,6 +270,8 @@ func ParseTx(address string, events []db.TaxableTransaction) (rows []parsers.Csv
 			rows = append(rows, ParseMsgSwapExactAmountOut(event))
 		case ibc.MsgTransfer:
 			rows = append(rows, ParseMsgTransfer(address, event))
+		case gov.MsgSubmitProposal:
+			rows = append(rows, ParseMsgSubmitProposal(address, event))
 		default:
 			return nil, fmt.Errorf("no parser for message type '%v'", event.Message.MessageType.MessageType)
 		}
@@ -353,6 +356,15 @@ func ParseMsgTransfer(address string, event db.TaxableTransaction) Row {
 	err := row.ParseBasic(address, event)
 	if err != nil {
 		config.Log.Fatal("Error with ParseMsgTransfer.", err)
+	}
+	return *row
+}
+
+func ParseMsgSubmitProposal(address string, event db.TaxableTransaction) Row {
+	row := &Row{}
+	err := row.ParseBasic(address, event)
+	if err != nil {
+		config.Log.Fatal("Error with ParseMsgSubmitProposal.", err)
 	}
 	return *row
 }

--- a/csv/parsers/taxbit/taxbit.go
+++ b/csv/parsers/taxbit/taxbit.go
@@ -8,6 +8,7 @@ import (
 	"github.com/DefiantLabs/cosmos-tax-cli/config"
 	"github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules/bank"
 	"github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules/distribution"
+	"github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules/gov"
 	"github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules/ibc"
 	"github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules/staking"
 	"github.com/DefiantLabs/cosmos-tax-cli/csv/parsers"
@@ -231,6 +232,8 @@ func ParseTx(address string, events []db.TaxableTransaction) (rows []parsers.Csv
 			rows = append(rows, ParseMsgWithdrawDelegatorReward(address, event))
 		case staking.MsgBeginRedelegate:
 			rows = append(rows, ParseMsgWithdrawDelegatorReward(address, event))
+		case gov.MsgSubmitProposal:
+			rows = append(rows, ParseMsgSubmitProposal(address, event))
 		case gamm.MsgSwapExactAmountIn:
 			rows = append(rows, ParseMsgSwapExactAmountIn(event))
 		case gamm.MsgSwapExactAmountOut:
@@ -321,6 +324,15 @@ func ParseMsgTransfer(address string, event db.TaxableTransaction) Row {
 	err := row.ParseBasic(address, event)
 	if err != nil {
 		config.Log.Fatal("Error with ParseMsgTransfer.", err)
+	}
+	return *row
+}
+
+func ParseMsgSubmitProposal(address string, event db.TaxableTransaction) Row {
+	row := &Row{}
+	err := row.ParseBasic(address, event)
+	if err != nil {
+		config.Log.Fatal("Error with ParseMsgSubmitProposal.", err)
 	}
 	return *row
 }


### PR DESCRIPTION
Add missing parsers for MsgSubmitProposal for CSV output formats of koinly, cointracker and taxbit.

Solves #315 