### PR TITLE
Add alternate parser for updated events for MsgExitSwapShareAmountIn …

### DIFF
--- a/cosmos/modules/tx/logic.go
+++ b/cosmos/modules/tx/logic.go
@@ -30,6 +30,23 @@ func GetEventWithType(eventType string, msg *LogMessage) *LogMessageEvent {
 	return nil
 }
 
+func GetAllEventsWithType(eventType string, msg *LogMessage) []LogMessageEvent {
+
+	var logEventMessages []LogMessageEvent
+
+	if msg == nil || msg.Events == nil {
+		return logEventMessages
+	}
+
+	for _, logEvent := range msg.Events {
+		if logEvent.Type == eventType {
+			logEventMessages = append(logEventMessages, logEvent)
+		}
+	}
+
+	return logEventMessages
+}
+
 // If order is reversed, the last attribute containing the given key will be returned
 // otherwise the first attribute will be returned
 func GetValueForAttribute(key string, evt *LogMessageEvent) string {

--- a/osmosis/handlers.go
+++ b/osmosis/handlers.go
@@ -12,7 +12,7 @@ var MessageTypeHandler = map[string][]func() txTypes.CosmosMessage{
 	gamm.MsgJoinSwapExternAmountIn:  {func() txTypes.CosmosMessage { return &gamm.WrapperMsgJoinSwapExternAmountIn{} }},
 	gamm.MsgJoinSwapShareAmountOut:  {func() txTypes.CosmosMessage { return &gamm.WrapperMsgJoinSwapShareAmountOut{} }},
 	gamm.MsgJoinPool:                {func() txTypes.CosmosMessage { return &gamm.WrapperMsgJoinPool{} }},
-	gamm.MsgExitSwapShareAmountIn:   {func() txTypes.CosmosMessage { return &gamm.WrapperMsgExitSwapShareAmountIn{} }},
+	gamm.MsgExitSwapShareAmountIn:   {func() txTypes.CosmosMessage { return &gamm.WrapperMsgExitSwapShareAmountIn{} }, func() txTypes.CosmosMessage { return &gamm.WrapperMsgExitSwapShareAmountIn2{} }},
 	gamm.MsgExitSwapExternAmountOut: {func() txTypes.CosmosMessage { return &gamm.WrapperMsgExitSwapExternAmountOut{} }},
 	gamm.MsgExitPool:                {func() txTypes.CosmosMessage { return &gamm.WrapperMsgExitPool{} }, func() txTypes.CosmosMessage { return &gamm.WrapperMsgExitPool2{} }},
 	gamm.MsgCreatePool:              {func() txTypes.CosmosMessage { return &gamm.WrapperMsgCreatePool{} }},


### PR DESCRIPTION
…for later blocks

Does the following:
1. Parses the Exit event as a list of tokens received
2. Parses the swap events each as a swap

This TX will now return multiple line items for this single TX to capture all that happened.

Tested locally on:

1. Block 2441293 for the old event format from a year ago
4. Block 8319511 containing TX 5DEACF0BD254B863928D09A43FC8F0E46C03295AAEEE6686EA833D443FA8B8D6
5. Block 8319740 containing TX BADBAFD9CB1C1CB18E47E4489C0BED243F0E5DEF75117541A2058C62399806AE

Closes #333 