### PR TITLE
Bug fixes stage 2 for 2021 Osmosis indexing

### DIFF
--- a/osmosis/handlers.go
+++ b/osmosis/handlers.go
@@ -9,7 +9,7 @@ import (
 var MessageTypeHandler = map[string][]func() txTypes.CosmosMessage{
 	gamm.MsgSwapExactAmountIn:       {func() txTypes.CosmosMessage { return &gamm.WrapperMsgSwapExactAmountIn{} }, func() txTypes.CosmosMessage { return &gamm.WrapperMsgSwapExactAmountIn2{} }, func() txTypes.CosmosMessage { return &gamm.WrapperMsgSwapExactAmountIn3{} }, func() txTypes.CosmosMessage { return &gamm.WrapperMsgSwapExactAmountIn4{} }},
 	gamm.MsgSwapExactAmountOut:      {func() txTypes.CosmosMessage { return &gamm.WrapperMsgSwapExactAmountOut{} }},
-	gamm.MsgJoinSwapExternAmountIn:  {func() txTypes.CosmosMessage { return &gamm.WrapperMsgJoinSwapExternAmountIn{} }},
+	gamm.MsgJoinSwapExternAmountIn:  {func() txTypes.CosmosMessage { return &gamm.WrapperMsgJoinSwapExternAmountIn{} }, func() txTypes.CosmosMessage { return &gamm.WrapperMsgJoinSwapExternAmountIn2{} }},
 	gamm.MsgJoinSwapShareAmountOut:  {func() txTypes.CosmosMessage { return &gamm.WrapperMsgJoinSwapShareAmountOut{} }},
 	gamm.MsgJoinPool:                {func() txTypes.CosmosMessage { return &gamm.WrapperMsgJoinPool{} }},
 	gamm.MsgExitSwapShareAmountIn:   {func() txTypes.CosmosMessage { return &gamm.WrapperMsgExitSwapShareAmountIn{} }, func() txTypes.CosmosMessage { return &gamm.WrapperMsgExitSwapShareAmountIn2{} }},

--- a/osmosis/modules/gamm/types.go
+++ b/osmosis/modules/gamm/types.go
@@ -730,10 +730,10 @@ func (sf *WrapperMsgJoinPool) HandleMsg(msgType string, msg sdk.Msg, log *txModu
 		var tokensIn string
 		var sender string
 		for i, attr := range transferEvt.Attributes {
-			if attr.Key == "amount" && !strings.Contains(attr.Value, "gamm/pool") && strings.Contains(attr.Value, ",") {
+			if attr.Key == "amount" && strings.Contains(attr.Value, ",") {
 				tokensIn = attr.Value
 				// If we haven't found the sender yet, it will be the address that sent this non-gamm token
-				if i > 0 && transferEvt.Attributes[i-1].Key == "sender" {
+				if i > 0 && transferEvt.Attributes[i-1].Key == "sender" && sf.OsmosisMsgJoinPool.Sender == transferEvt.Attributes[i-1].Value {
 					sender = transferEvt.Attributes[i-1].Value
 				}
 				break


### PR DESCRIPTION
Implement fixes for the following bugs found when indexing blocks 148,513 - 250,000:

1. Invalid logic in fallback parser for MsgJoinPool that didn't allow joining with GAMM (which some pools use)
2. A second parser path for old formats of MsgSwapExactAmountOut
3. A second parser function for old formats of MsgJoinSwapExternAmountIn

Closes #356 
Closes #357 
Closes #358 