### PR TITLE
Bug fixes 2021 osmosis indexing v3

### DIFF
--- a/core/tx.go
+++ b/core/tx.go
@@ -91,6 +91,7 @@ var messageTypeIgnorer = map[string]interface{}{
 	lockup.MsgLockTokens:        nil,
 	lockup.MsgBeginUnlockingAll: nil,
 	lockup.MsgUnlockPeriodLock:  nil,
+	lockup.MsgUnlockTokens:      nil,
 	// Unjailing and updating params is not taxable
 	slashing.MsgUnjail:       nil,
 	slashing.MsgUpdateParams: nil,

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/BurntSushi/toml v1.2.1
 	// FYI, you can do go get github.com/DefiantLabs/lens@1f6f34841280df179c6e098f040bd584ced43a4c
 	// (using the commit hash from github) to pin to a specific commit.
-	github.com/DefiantLabs/lens v0.3.1-0.20230326160437-65b383c74a1a
+	github.com/DefiantLabs/lens v0.3.1-0.20230329215548-1c008fbd71af
 	github.com/cosmos/cosmos-sdk v0.46.7
 	github.com/gin-gonic/gin v1.9.0
 	github.com/go-co-op/gocron v1.13.0

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,8 @@ github.com/CosmWasm/wasmvm v1.1.1/go.mod h1:ei0xpvomwSdONsxDuONzV7bL1jSET1M8brEx
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/zstd v1.4.1/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/DataDog/zstd v1.4.5/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
-github.com/DefiantLabs/lens v0.3.1-0.20230326160437-65b383c74a1a h1:t5cvUHq/nxbYgaSTz6jVmvKmUpBPjCEgtOy6GutlCZ8=
-github.com/DefiantLabs/lens v0.3.1-0.20230326160437-65b383c74a1a/go.mod h1:Kw6wTyAe3wHZ+CaRfmv5APzPT4m57yECfKV8jVMU6vQ=
+github.com/DefiantLabs/lens v0.3.1-0.20230329215548-1c008fbd71af h1:WLc+7ETbSnhktNvlqT++a6RoUX5Md+gZyRpfh1pNC6w=
+github.com/DefiantLabs/lens v0.3.1-0.20230329215548-1c008fbd71af/go.mod h1:Kw6wTyAe3wHZ+CaRfmv5APzPT4m57yECfKV8jVMU6vQ=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc=
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=

--- a/osmosis/handlers.go
+++ b/osmosis/handlers.go
@@ -10,7 +10,7 @@ var MessageTypeHandler = map[string][]func() txTypes.CosmosMessage{
 	gamm.MsgSwapExactAmountIn:       {func() txTypes.CosmosMessage { return &gamm.WrapperMsgSwapExactAmountIn{} }, func() txTypes.CosmosMessage { return &gamm.WrapperMsgSwapExactAmountIn2{} }, func() txTypes.CosmosMessage { return &gamm.WrapperMsgSwapExactAmountIn3{} }, func() txTypes.CosmosMessage { return &gamm.WrapperMsgSwapExactAmountIn4{} }},
 	gamm.MsgSwapExactAmountOut:      {func() txTypes.CosmosMessage { return &gamm.WrapperMsgSwapExactAmountOut{} }},
 	gamm.MsgJoinSwapExternAmountIn:  {func() txTypes.CosmosMessage { return &gamm.WrapperMsgJoinSwapExternAmountIn{} }, func() txTypes.CosmosMessage { return &gamm.WrapperMsgJoinSwapExternAmountIn2{} }},
-	gamm.MsgJoinSwapShareAmountOut:  {func() txTypes.CosmosMessage { return &gamm.WrapperMsgJoinSwapShareAmountOut{} }},
+	gamm.MsgJoinSwapShareAmountOut:  {func() txTypes.CosmosMessage { return &gamm.WrapperMsgJoinSwapShareAmountOut{} }, func() txTypes.CosmosMessage { return &gamm.WrapperMsgJoinSwapShareAmountOut2{} }},
 	gamm.MsgJoinPool:                {func() txTypes.CosmosMessage { return &gamm.WrapperMsgJoinPool{} }},
 	gamm.MsgExitSwapShareAmountIn:   {func() txTypes.CosmosMessage { return &gamm.WrapperMsgExitSwapShareAmountIn{} }, func() txTypes.CosmosMessage { return &gamm.WrapperMsgExitSwapShareAmountIn2{} }},
 	gamm.MsgExitSwapExternAmountOut: {func() txTypes.CosmosMessage { return &gamm.WrapperMsgExitSwapExternAmountOut{} }},

--- a/osmosis/modules/lockup/types.go
+++ b/osmosis/modules/lockup/types.go
@@ -6,4 +6,5 @@ const (
 	MsgLockTokens        = "/osmosis.lockup.MsgLockTokens" // nolint:gosec
 	MsgBeginUnlockingAll = "/osmosis.lockup.MsgBeginUnlockingAll"
 	MsgUnlockPeriodLock  = "/osmosis.lockup.MsgUnlockPeriodLock"
+	MsgUnlockTokens      = "/osmosis.lockup.MsgUnlockTokens"
 )


### PR DESCRIPTION
Fixes bugs for the following issues:

1. A missing codec for MsgUnlockTokens. This was added to our lens fork on a new branch [v0.0.11-dl](https://github.com/DefiantLabs/lens/tree/v0.0.11-dl)
2. A failing MsgJoinSwapShareAmountOut parser due to old message event formats. An alternate parser was added that supports this format.

Closes #360 
Closes #361 