### PR TITLE
Update lens fork version to support protorev messages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/BurntSushi/toml v1.2.1
 	// FYI, you can do go get github.com/DefiantLabs/lens@1f6f34841280df179c6e098f040bd584ced43a4c
 	// (using the commit hash from github) to pin to a specific commit.
-	github.com/DefiantLabs/lens v0.3.1-0.20230330024006-1609b0a7b227
+	github.com/DefiantLabs/lens v0.3.1-0.20230401205822-786fdae8c0ff
 	github.com/cosmos/cosmos-sdk v0.46.10
 	github.com/gin-gonic/gin v1.9.0
 	github.com/go-co-op/gocron v1.13.0

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,8 @@ github.com/CosmWasm/wasmvm v1.1.1/go.mod h1:ei0xpvomwSdONsxDuONzV7bL1jSET1M8brEx
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/zstd v1.4.1/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/DataDog/zstd v1.4.5/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
-github.com/DefiantLabs/lens v0.3.1-0.20230330024006-1609b0a7b227 h1:02aAC8SqL3PaFsYUG9Nlp17AKxSAQF3t+E2Wnw9Am/0=
-github.com/DefiantLabs/lens v0.3.1-0.20230330024006-1609b0a7b227/go.mod h1:iYXij2G8daws2xBOYNzyMNlasr7vJJTOJkVk7aXkMXw=
+github.com/DefiantLabs/lens v0.3.1-0.20230401205822-786fdae8c0ff h1:sWEzpIkGiFbgf0IuKTeZ/5+ewhrGpmiPNYJWzgYozgw=
+github.com/DefiantLabs/lens v0.3.1-0.20230401205822-786fdae8c0ff/go.mod h1:iYXij2G8daws2xBOYNzyMNlasr7vJJTOJkVk7aXkMXw=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc=
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=


### PR DESCRIPTION
Updating the Lens fork version to the branch [v0.0.13-dl](https://github.com/DefiantLabs/lens/tree/v0.0.13-dl) will add support for processing the new Osmosis `protorev` module. This will also have the downstream effect of fixing the bug in issue #367 which was erroring due to this missing support.

Closes #367 