### PR TITLE
feat: index ibc denom trace metadata

### DIFF
--- a/cmd/index.go
+++ b/cmd/index.go
@@ -69,6 +69,12 @@ func setupIndexer() *Indexer {
 		if err != nil {
 			config.Log.Error("Error scheduling denom upsert task. Err: ", err)
 		}
+
+		_, err = idxr.scheduler.Every(6).Hours().Do(tasks.IBCDenomUpsertTask, idxr.cfg.Base.API, idxr.db)
+		if err != nil {
+			config.Log.Error("Error scheduling ibc denom upsert task. Err: ", err)
+		}
+
 		idxr.scheduler.StartAsync()
 	}
 

--- a/cosmos/modules/denoms/types.go
+++ b/cosmos/modules/denoms/types.go
@@ -1,5 +1,7 @@
 package denoms
 
+import transfertypes "github.com/cosmos/ibc-go/v4/modules/apps/transfer/types"
+
 type GetDenomsMetadatasResponse struct {
 	Metadatas  []Metadata `json:"metadatas"`
 	Pagination Pagination `json:"pagination"`
@@ -23,4 +25,9 @@ type DenomUnit struct {
 type Pagination struct {
 	NextKey string `json:"next_key"`
 	Total   string `json:"total"`
+}
+
+type GetDenomTracesResponse struct {
+	DenomTraces transfertypes.Traces `json:"denom_traces"`
+	Pagination  Pagination           `json:"pagination"`
 }

--- a/db/db.go
+++ b/db/db.go
@@ -59,6 +59,7 @@ func MigrateModels(db *gorm.DB) error {
 		&Denom{},
 		&DenomUnit{},
 		&DenomUnitAlias{},
+		&IBCDenom{},
 	)
 }
 
@@ -310,6 +311,20 @@ func UpsertDenoms(db *gorm.DB, denoms []DenomDBWrapper) error {
 						return err
 					}
 				}
+			}
+		}
+		return nil
+	})
+}
+
+func UpsertIBCDenoms(db *gorm.DB, denoms []IBCDenom) error {
+	return db.Transaction(func(dbTransaction *gorm.DB) error {
+		for _, denom := range denoms {
+			if err := dbTransaction.Clauses(clause.OnConflict{
+				Columns:   []clause.Column{{Name: "hash"}},
+				DoUpdates: clause.AssignmentColumns([]string{"path", "base_denom"}),
+			}).Create(&denom).Error; err != nil {
+				return err
 			}
 		}
 		return nil

--- a/db/models.go
+++ b/db/models.go
@@ -170,3 +170,10 @@ type DenomUnitDBWrapper struct {
 	DenomUnit DenomUnit
 	Aliases   []DenomUnitAlias
 }
+
+type IBCDenom struct {
+	ID        uint
+	Hash      string `gorm:"uniqueIndex"`
+	Path      string
+	BaseDenom string
+}


### PR DESCRIPTION
This is the first PR on the road to supporting IBC denoms and msg types. We recursively query the `/ibc/apps/transfer/v1/denom_traces` REST endpoint to fetch all IBC denom traces, which returns results that look like this

```json
"denom_traces": [
    {
      "path": "transfer/channel-0/transfer/channel-109",
      "base_denom": "basecro"
    }
]
```

where `path` describes the port/channel's that this token has travelled across and `base_denom` represents the actual denom of the underlying asset.

When you query txs you don't see the IBC denom traces in this format though and instead see the "IBC Denom" which is represented by `ibc/{hash(path + baseDenom)}`, so we index all of the denom traces along with the IBC denom so that as txs are indexed a lookup can be performed to obtain the actual base denom of this token.

This doesn't fully close out #17 but it does at least index the IBC related denom data that will be necessary for removing the `unk` denoms currently being indexed.