### PR TITLE
#311: Fix bad logic on indexer startup and retry when EOF error is found in Status endpoint

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -112,6 +112,8 @@ func initConfig() {
 	if err != nil {
 		if strings.Contains(err.Error(), "Config File \"config\" Not Found") {
 			noConfig = true
+		} else if strings.Contains(err.Error(), "incomplete number") {
+			log.Fatalf("Failed to read config file %v. This usually means you forgot to wrap a string in quotes.", err)
 		} else {
 			log.Fatalf("Failed to read config file. Err: %v", err)
 		}


### PR DESCRIPTION
* Remove bad flag usage in indexer setup when waiting for chain to finish syncing. The ExitWhenCaughtUp flag should not be used here
* Add a second retry for querying chain status due to random EOF errors coming from the node

I could reproduce the EOF pretty easily, but I think its not a problem in our code. I think the Node is sending an EOF randomly, we would need to see logs on the node side to confirm this.

Closes #311 