### PR TITLE
Improved failed block handling

### DIFF
--- a/core/tx.go
+++ b/core/tx.go
@@ -213,7 +213,7 @@ func ProcessRPCBlockByHeightTXs(db *gorm.DB, cl *client.ChainClient, blockResult
 		txDecoder := cl.Codec.TxConfig.TxDecoder()
 		txBasic, err := txDecoder(tendermintTx)
 		if err != nil {
-			config.Log.Fatalf("ProcessRPCBlockByHeightTXs: TX cannot be parsed from block %v. Err: %v", blockResults.Block.Height, err)
+			return nil, blockTime, fmt.Errorf("ProcessRPCBlockByHeightTXs: TX cannot be parsed from block %v. Err: %v", blockResults.Block.Height, err)
 		}
 
 		// This is a hack, but as far as I can tell necessary. "wrapper" struct is private in Cosmos SDK.

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/BurntSushi/toml v1.2.1
 	// FYI, you can do go get github.com/DefiantLabs/lens@1f6f34841280df179c6e098f040bd584ced43a4c
 	// (using the commit hash from github) to pin to a specific commit.
-	github.com/DefiantLabs/lens v0.3.1-0.20230401205822-786fdae8c0ff
+	github.com/DefiantLabs/lens v0.3.1-0.20230416023355-99f22777c0fc
 	github.com/cosmos/cosmos-sdk v0.46.10
 	github.com/gin-gonic/gin v1.9.0
 	github.com/go-co-op/gocron v1.13.0

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,8 @@ github.com/CosmWasm/wasmvm v1.1.1/go.mod h1:ei0xpvomwSdONsxDuONzV7bL1jSET1M8brEx
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/zstd v1.4.1/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/DataDog/zstd v1.4.5/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
-github.com/DefiantLabs/lens v0.3.1-0.20230401205822-786fdae8c0ff h1:sWEzpIkGiFbgf0IuKTeZ/5+ewhrGpmiPNYJWzgYozgw=
-github.com/DefiantLabs/lens v0.3.1-0.20230401205822-786fdae8c0ff/go.mod h1:iYXij2G8daws2xBOYNzyMNlasr7vJJTOJkVk7aXkMXw=
+github.com/DefiantLabs/lens v0.3.1-0.20230416023355-99f22777c0fc h1:Gek/Xk5TGgMW6LomYi6gfm2GB4efio1L63YYAmxrOGc=
+github.com/DefiantLabs/lens v0.3.1-0.20230416023355-99f22777c0fc/go.mod h1:iYXij2G8daws2xBOYNzyMNlasr7vJJTOJkVk7aXkMXw=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc=
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=


### PR DESCRIPTION
Fix bugs and improve behavior around failed block handling:

* Remove fatal errors from processBlock and downstream function calls
* Always return an error if a block failed to be processed in for any reason
* Remove retry code around block processing, always default to adding to failed block table and moving on
* Update lens dep to branch version that does not error out on transactions that could not be unpacked (this will later allow us to continue processing transactions that could be unpacked)

# Deeper dive

## Removing fatal errors

There were 3 locations where we crashed the app on errors, all in our newer second querier fallback codeblock. These were preventing us from indexing in many scenarios. I now have the code defaulting to adding a failed block to the database and continuing on.

## Always return an error on failed block processing

There were a few instances in processBlock where errors were not returned. This means these errors would silently "succeed" and not be added to the failed blocks table. These errors will now be added to the failed blocks table.

## Removing block error retry code

We had a total of 5 retry attempts on every failed block. I think this is a bad idea for a number of reasons:

1. Not all downstream errors are retryable, reattempting will not make a difference for these ones
2. Each retry requires calling RPC endpoints, bashing the RPC server
3. We do not have a concept of "retryable" error, we should build this in before attempting retries
4. As we index new chains, we will more frequently come across blocks that failed to process. This will be because we do not have parsing support for these chains yet, so their personal module messages will ALWAYS fail. We should not retry 5 times in these instances.

## Lens update

The update for our Lens dep uses a branch that will not throw errors if a transaction cannot be unpacked. This happens when we have not registered the messages in our Lens fork, which will happen much more frequently on new chains. This will allow us to continue on and add blocks to the failed blocks table if a transaction is new to Lens.