### PR TITLE
Bump Lens fork version

### DIFF
--- a/core/tx.go
+++ b/core/tx.go
@@ -107,14 +107,16 @@ var messageTypeIgnorer = map[string]interface{}{
 	// Create account is not taxable
 	vesting.MsgCreateVestingAccount: nil,
 
-	///////////////////////////////////////////
-	/////// Taxable Events, future work ///////
-	///////////////////////////////////////////
-	// We do not currently support the tendermint liquidity pool module
+	// Tendermint Liquidity messages are actually executed in batches during periodic EndBlocker events
+	// We ignore the Message types since the actual taxable events happen later, and the messages can fail/be refunded
 	liquidity.MsgCreatePool:          nil,
 	liquidity.MsgDepositWithinBatch:  nil,
 	liquidity.MsgWithdrawWithinBatch: nil,
 	liquidity.MsgSwapWithinBatch:     nil,
+
+	///////////////////////////////////////////
+	/////// Taxable Events, future work ///////
+	///////////////////////////////////////////
 	// CosmWasm
 	wasm.MsgExecuteContract:     nil,
 	wasm.MsgInstantiateContract: nil,

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/BurntSushi/toml v1.2.1
 	// FYI, you can do go get github.com/DefiantLabs/lens@1f6f34841280df179c6e098f040bd584ced43a4c
 	// (using the commit hash from github) to pin to a specific commit.
-	github.com/DefiantLabs/lens v0.3.1-0.20230416023355-99f22777c0fc
+	github.com/DefiantLabs/lens v0.3.1-0.20230428023132-a51c06c87677
 	github.com/cosmos/cosmos-sdk v0.46.10
 	github.com/gin-gonic/gin v1.9.0
 	github.com/go-co-op/gocron v1.13.0

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,8 @@ github.com/CosmWasm/wasmvm v1.1.1/go.mod h1:ei0xpvomwSdONsxDuONzV7bL1jSET1M8brEx
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/zstd v1.4.1/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/DataDog/zstd v1.4.5/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
-github.com/DefiantLabs/lens v0.3.1-0.20230416023355-99f22777c0fc h1:Gek/Xk5TGgMW6LomYi6gfm2GB4efio1L63YYAmxrOGc=
-github.com/DefiantLabs/lens v0.3.1-0.20230416023355-99f22777c0fc/go.mod h1:iYXij2G8daws2xBOYNzyMNlasr7vJJTOJkVk7aXkMXw=
+github.com/DefiantLabs/lens v0.3.1-0.20230428023132-a51c06c87677 h1:yznj6Qm+9YsnQrsWBc6GyDTzPTl4T1AM+DIPS9psY50=
+github.com/DefiantLabs/lens v0.3.1-0.20230428023132-a51c06c87677/go.mod h1:iYXij2G8daws2xBOYNzyMNlasr7vJJTOJkVk7aXkMXw=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc=
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=


### PR DESCRIPTION
Bump Lens fork version to commit that will properly parse Tendermint Liquidity types, but keep them ignored (this will allow CosmosHub to be indexed without failing).

Closes #383 

# How it Works

I have used a new method suggested by @jtieri to handle the Tendermint Liquidity message types in our Lens fork.

Instead of including the entire module, I have just done the following:

1. Included the Message proto file only  - [source](https://github.com/DefiantLabs/lens/blob/a51c06c87677871fd5a40816b862f4ac6ddf0f8b/proto/tendermint/liquidity/v1beta1/tx.proto)
2. Generated the Message protobuf message type definitions using the [buf](https://github.com/bufbuild/buf) program
    * [source](https://github.com/DefiantLabs/lens/blob/a51c06c87677871fd5a40816b862f4ac6ddf0f8b/tendermint/x/liquidity/types/tx.pb.go)
3. Built the Tendermint Liquidity Message interface definitions and Codec implementation:
    * Message interface definitions - [source](https://github.com/DefiantLabs/lens/blob/v0.0.15-dl/tendermint/x/liquidity/types/msgs.go)
    * Codec implementation - [source](https://github.com/DefiantLabs/lens/blob/a51c06c87677871fd5a40816b862f4ac6ddf0f8b/tendermint/x/liquidity/types/codecs.go)
4. Included the Codec in the base Lens codec - [source](https://github.com/DefiantLabs/lens/blob/a51c06c87677871fd5a40816b862f4ac6ddf0f8b/client/encoding.go#L38)

# How it was Tested

I tested this in 2 ways on 2 different branches to make sure the above process works. One way is the way we are taking the main branch (this PR), the other way is a branch I was working on to support indexing the messages.

## Testing blocks

I ran the code on the following **CosmosHub** blocks:

* 7453602 - has Tendermint Liquidity TX DepositWithinBatch
* 8318996- has Tendermint Liquidity TX SwapWithinBatch
* 10121645 - has Tendermint Liquidity WithdrawWithinBatch

## This Branch

On this branch, the code ignores the above Message types in Liquidity.

We have decided to continue to ignore the messages since the Liquidity modules executes the actual work for Swaps, Deposits and Withdraws in the EndBlocker state transition.

See this PR for details: https://github.com/DefiantLabs/cosmos-tax-cli/pull/391

## Alternate Branch - The initial push to index Tendermint Messages

I used this branch here: [383-tendermint-liquidity-message-indexing](https://github.com/DefiantLabs/cosmos-tax-cli/tree/383-tendermint-liquidity-message-indexing)

Before taking the codebase in the above direction with the linked PR, I had implemented Message Indexing for DepositWithinBatch and WithdrawWithinBatch.

The methods followed our normal message indexing, requiring message specific handlers and type parsing.

Using the new Lens fork branch, I was successfully able to index the above message types, e.g.:

```
Block: 7453602] Cosmos message of known type: MsgDepositWithinBatch: cosmos1sr0lw3rnl4u3zz7hxrek0pp26hjhapecr4dyyj deposited 4250003ibc/2181AAB0218EAC24BC9F86BD1364FBBFA3E6E3FCC25E88E3E68C15DC6E752D86, 689313uatom
...
DBG [Block: 10121645] Cosmos message of known type: MsgWithdrawWithinBatch: cosmos1sr0lw3rnl4u3zz7hxrek0pp26hjhapecr4dyyj withdrew 23poolF2805980C54E1474BDCCF70EF5FE881F3B8EFCF8BA3198765C01D91904521788
```

I am including this portion of the writeup to prove that the new methodology in our Lens fork allows us to index the message without including the **entire** Tendermint Liquidity module.

# Going Forward

I highly recommend we continue to use this methodology when we need to include new Blockchain modules within the indexer for the following reasons:

1. It keeps our Lens fork lightweight - we only need to index messages, so we should not include entire modules
2. We do not need to worry about figuring out how to include entire modules for differing blockchains
3. It takes advantage of the generalized nature of protobuf