### PR TITLE
chore: add golangci-lint and fix ST1005 issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,62 @@
+run:
+  tests: true
+  # timeout for analysis, e.g. 30s, 5m, default is 1m
+  timeout: 5m
+
+linters:
+  disable-all: true
+  enable:
+    - depguard
+    - dogsled
+    - exportloopref
+    - errcheck
+    - goconst
+    - gocritic
+    - gofumpt
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - misspell
+    - nakedret
+    - staticcheck
+    - stylecheck
+    - revive
+    - typecheck
+    - unconvert
+    - unused
+    - misspell
+
+issues:
+  exclude-rules:
+    - text: "unused-parameter"
+      linters:
+        - revive
+    - text: "SA1019:"
+      linters:
+        - staticcheck
+    - text: "Use of weak random number generator"
+      linters:
+        - gosec
+    - text: "ST1003:"
+      linters:
+        - stylecheck
+    # FIXME: Disabled until golangci-lint updates stylecheck with this fix:
+    # https://github.com/dominikh/go-tools/issues/389
+    - text: "ST1016:"
+      linters:
+        - stylecheck
+  max-issues-per-linter: 10000
+  max-same-issues: 10000
+
+linters-settings:
+  dogsled:
+    max-blank-identifiers: 3
+  maligned:
+    # print struct with more effective memory layout or not, false by default
+    suggest-new: true
+  nolintlint:
+    allow-unused: false
+    allow-leading-space: true
+    require-explanation: false
+    require-specific: false

--- a/Makefile
+++ b/Makefile
@@ -33,3 +33,7 @@ build-docker-amd:
 build-docker-arm:
 	docker build -t $(FQCN):$(VERSION) -f ./Dockerfile \
 	--build-arg TARGETPLATFORM=linux/arm64 .
+
+.PHONY: lint
+lint: ## Run golangci-linter
+	golangci-lint run --out-format=tab

--- a/client/client.go
+++ b/client/client.go
@@ -230,7 +230,7 @@ func GetTaxableEventsCSV(c *gin.Context) {
 		// the error returned here has already been pushed to the context... I think.
 		config.Log.Errorf("Error getting rows for addresses: %v", addresses)
 		fmt.Println(err)
-		c.AbortWithError(500, errors.New("Error getting rows for address")) // nolint:staticcheck,errcheck
+		c.AbortWithError(500, errors.New("error getting rows for address")) // nolint:staticcheck,errcheck
 		return
 	}
 
@@ -272,7 +272,7 @@ func GetTaxableEventsJSON(c *gin.Context) {
 	if err != nil {
 		// the error returned here has already been pushed to the context... I think.
 		config.Log.Errorf("Error getting rows for addresses: %v", addresses)
-		c.AbortWithError(500, errors.New("Error getting rows for address")) // nolint:staticcheck,errcheck
+		c.AbortWithError(500, errors.New("error getting rows for address")) // nolint:staticcheck,errcheck
 		return
 	}
 
@@ -290,7 +290,7 @@ func ParseTaxableEventsBody(c *gin.Context) ([]string, string, *time.Time, *time
 
 	if err != nil {
 		// the error returned here has already been pushed to the context... I think.
-		c.AbortWithError(500, errors.New("Error processing request body")) // nolint:staticcheck,errcheck
+		c.AbortWithError(500, errors.New("error processing request body")) // nolint:staticcheck,errcheck
 		return nil, "", nil, nil, err
 	}
 
@@ -332,7 +332,7 @@ func ParseTaxableEventsBody(c *gin.Context) ([]string, string, *time.Time, *time
 
 	if format == "" {
 		c.JSON(422, gin.H{"message": "Format is required"})
-		return nil, "", nil, nil, errors.New("Format is required")
+		return nil, "", nil, nil, errors.New("format is required")
 	}
 
 	return addresses, format, startDate, endDate, nil

--- a/core/block_events.go
+++ b/core/block_events.go
@@ -70,7 +70,7 @@ func ProcessRPCBlockEvents(blockResults *ctypes.ResultBlockResults) ([]eventType
 
 			// If err is not nil here, all handlers failed
 			if err != nil {
-				return nil, fmt.Errorf("Could not handle event type %s, all handlers failed", event.Type)
+				return nil, fmt.Errorf("could not handle event type %s, all handlers failed", event.Type)
 			}
 		}
 	}
@@ -101,7 +101,7 @@ func ProcessRPCBlockEvents(blockResults *ctypes.ResultBlockResults) ([]eventType
 
 			// If err is not nil here, all handlers failed
 			if err != nil {
-				return nil, fmt.Errorf("Could not handle event type %s, all handlers failed", event.Type)
+				return nil, fmt.Errorf("could not handle event type %s, all handlers failed", event.Type)
 			}
 		}
 	}

--- a/csv/parser.go
+++ b/csv/parser.go
@@ -48,7 +48,7 @@ func GetParser(parserKey string) parsers.Parser {
 func ParseForAddress(addresses []string, startDate, endDate *time.Time, pgSQL *gorm.DB, parserKey string, cfg config.Config) ([]parsers.CsvRow, []string, error) {
 	parser := GetParser(parserKey)
 	if parser == nil {
-		return nil, nil, errors.New("Invalid parser key")
+		return nil, nil, errors.New("invalid parser key")
 	}
 	parser.InitializeParsingGroups()
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -33,7 +33,7 @@ services:
 
   indexer:
     restart: "no"
-    image: cosmos-cli:local
+    image: ghcr.io/defiantlabs/cosmos-tax-cli:main
     user: defiant
     stop_grace_period: 10s
     volumes:
@@ -57,7 +57,7 @@ services:
       --log.pretty = true \
       --log.level = debug \
       --base.index-chain = false \
-      --base.start-block 2723300 \
+      --base.start-block 2723462 \
       --base.end-block 2723464 \
       --base.index-rewards = true \
       --base.rewards-start-block 4535620 \

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -33,7 +33,7 @@ services:
 
   indexer:
     restart: "no"
-    image: ghcr.io/defiantlabs/cosmos-tax-cli:main
+    image: cosmos-cli:local
     user: defiant
     stop_grace_period: 10s
     volumes:
@@ -57,7 +57,7 @@ services:
       --log.pretty = true \
       --log.level = debug \
       --base.index-chain = false \
-      --base.start-block 2723462 \
+      --base.start-block 2723300 \
       --base.end-block 2723464 \
       --base.index-rewards = true \
       --base.rewards-start-block 4535620 \

--- a/osmosis/events/incentives/types.go
+++ b/osmosis/events/incentives/types.go
@@ -43,7 +43,7 @@ func (sf *WrapperBlockDistribution) HandleEvent(eventType string, event abciType
 		sf.ReceiverAddress = receiverAddr
 		sf.RewardsReceived = coins
 	} else {
-		return errors.New("Rewards received or address were not present")
+		return errors.New("rewards received or address were not present")
 	}
 
 	return nil

--- a/tendermint/events/liquidity/types.go
+++ b/tendermint/events/liquidity/types.go
@@ -125,13 +125,13 @@ func (sf *WrapperBlockEventSwapTransacted) HandleEvent(eventType string, event a
 
 	offerAmount, ok := sdk.NewIntFromString(offerCoinAmount)
 	if !ok {
-		return fmt.Errorf("Error parsing coin amount for offerCoinAmount %s", offerCoinAmount)
+		return fmt.Errorf("error parsing coin amount for offerCoinAmount %s", offerCoinAmount)
 	}
 	sf.CoinSwappedIn = sdk.NewCoin(offerCoinDenom, offerAmount)
 
 	demandAmount, ok := sdk.NewIntFromString(demandCoinAmount)
 	if !ok {
-		return fmt.Errorf("Error parsing coin amount for demandCoinAmount %s", demandCoinAmount)
+		return fmt.Errorf("error parsing coin amount for demandCoinAmount %s", demandCoinAmount)
 	}
 	sf.CoinSwappedOut = sdk.NewCoin(demandCoinDenom, demandAmount)
 
@@ -141,7 +141,7 @@ func (sf *WrapperBlockEventSwapTransacted) HandleEvent(eventType string, event a
 	}
 	offerFeeAmount, ok := sdk.NewIntFromString(offerCoinFeeAmount)
 	if !ok {
-		return fmt.Errorf("Error parsing coin amount for offerCoinFeeAmount %s", offerCoinFeeAmount)
+		return fmt.Errorf("error parsing coin amount for offerCoinFeeAmount %s", offerCoinFeeAmount)
 	}
 	firstFee := sdk.NewCoin(offerCoinDenom, offerFeeAmount)
 
@@ -151,7 +151,7 @@ func (sf *WrapperBlockEventSwapTransacted) HandleEvent(eventType string, event a
 	}
 	demandFeeAmount, ok := sdk.NewIntFromString(demandCoinFeeAmount)
 	if !ok {
-		return fmt.Errorf("Error parsing coin amount for demandCoinFeeAmount %s", demandCoinFeeAmount)
+		return fmt.Errorf("error parsing coin amount for demandCoinFeeAmount %s", demandCoinFeeAmount)
 	}
 	secondFee := sdk.NewCoin(demandCoinDenom, demandFeeAmount)
 


### PR DESCRIPTION
This adds the golangci-lint yaml file to the repo to enforce some idiomatic conventions and best practices across the repo.

I've also fixed the first set of linter errors, `ST1005: error strings should not be capitalized`. Tackling all of the linter errors in one issue makes the PRs harder to review so I will have a series of follow up PRs to address the remaining linter errors.

Closes #331 