### PR TITLE
chore: fix the rest of the stylecheck linter errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,62 @@
+run:
+  tests: true
+  # timeout for analysis, e.g. 30s, 5m, default is 1m
+  timeout: 5m
+
+linters:
+  disable-all: true
+  enable:
+    - depguard
+    - dogsled
+    - exportloopref
+    - errcheck
+    - goconst
+    - gocritic
+    - gofumpt
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - misspell
+    - nakedret
+    - staticcheck
+    - stylecheck
+    - revive
+    - typecheck
+    - unconvert
+    - unused
+    - misspell
+
+issues:
+  exclude-rules:
+    - text: "unused-parameter"
+      linters:
+        - revive
+    - text: "SA1019:"
+      linters:
+        - staticcheck
+    - text: "Use of weak random number generator"
+      linters:
+        - gosec
+    - text: "ST1003:"
+      linters:
+        - stylecheck
+    # FIXME: Disabled until golangci-lint updates stylecheck with this fix:
+    # https://github.com/dominikh/go-tools/issues/389
+    - text: "ST1016:"
+      linters:
+        - stylecheck
+  max-issues-per-linter: 10000
+  max-same-issues: 10000
+
+linters-settings:
+  dogsled:
+    max-blank-identifiers: 3
+  maligned:
+    # print struct with more effective memory layout or not, false by default
+    suggest-new: true
+  nolintlint:
+    allow-unused: false
+    allow-leading-space: true
+    require-explanation: false
+    require-specific: false

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,9 +32,6 @@ issues:
     - text: "unused-parameter"
       linters:
         - revive
-    - text: "SA1019:"
-      linters:
-        - staticcheck
     - text: "Use of weak random number generator"
       linters:
         - gosec

--- a/Makefile
+++ b/Makefile
@@ -37,3 +37,7 @@ build-docker-arm:
 .PHONY: lint
 lint: ## Run golangci-linter
 	golangci-lint run --out-format=tab
+
+.PHONY: format
+format: ## Formats the code with gofumpt
+	find . -name '*.go' -type f -not -path "./vendor*" -not -path "*.git*" -not -path "./client/docs/*" | xargs gofumpt -w

--- a/Makefile
+++ b/Makefile
@@ -33,3 +33,7 @@ build-docker-amd:
 build-docker-arm:
 	docker build -t $(FQCN):$(VERSION) -f ./Dockerfile \
 	--build-arg TARGETPLATFORM=linux/arm64 .
+
+.PHONY: lint
+lint: ## Run golangci-linter
+	golangci-lint run --out-format=tab

--- a/assetlists/assetlists.go
+++ b/assetlists/assetlists.go
@@ -15,7 +15,6 @@ func GetAssetList(url string) (AssetList, error) {
 	defer resp.Body.Close()
 
 	resBody, err := io.ReadAll(resp.Body)
-
 	if err != nil {
 		return assetList, err
 	}

--- a/assetlists/types.go
+++ b/assetlists/types.go
@@ -9,5 +9,5 @@ type Asset struct {
 	Description string `json:"description"`
 	Base        string `json:"base"`
 	Symbol      string `json:"symbol"`
-	KoinlyId    string `json:"koinly_id"` //currently stored as a string in our assetlist
+	KoinlyId    string `json:"koinly_id"` // currently stored as a string in our assetlist
 }

--- a/client/client.go
+++ b/client/client.go
@@ -230,7 +230,7 @@ func GetTaxableEventsCSV(c *gin.Context) {
 		// the error returned here has already been pushed to the context... I think.
 		config.Log.Errorf("Error getting rows for addresses: %v", addresses)
 		fmt.Println(err)
-		c.AbortWithError(500, errors.New("Error getting rows for address")) // nolint:staticcheck,errcheck
+		c.AbortWithError(500, errors.New("error getting rows for address")) // nolint:staticcheck,errcheck
 		return
 	}
 
@@ -272,7 +272,7 @@ func GetTaxableEventsJSON(c *gin.Context) {
 	if err != nil {
 		// the error returned here has already been pushed to the context... I think.
 		config.Log.Errorf("Error getting rows for addresses: %v", addresses)
-		c.AbortWithError(500, errors.New("Error getting rows for address")) // nolint:staticcheck,errcheck
+		c.AbortWithError(500, errors.New("error getting rows for address")) // nolint:staticcheck,errcheck
 		return
 	}
 
@@ -290,7 +290,7 @@ func ParseTaxableEventsBody(c *gin.Context) ([]string, string, *time.Time, *time
 
 	if err != nil {
 		// the error returned here has already been pushed to the context... I think.
-		c.AbortWithError(500, errors.New("Error processing request body")) // nolint:staticcheck,errcheck
+		c.AbortWithError(500, errors.New("error processing request body")) // nolint:staticcheck,errcheck
 		return nil, "", nil, nil, err
 	}
 
@@ -332,7 +332,7 @@ func ParseTaxableEventsBody(c *gin.Context) ([]string, string, *time.Time, *time
 
 	if format == "" {
 		c.JSON(422, gin.H{"message": "Format is required"})
-		return nil, "", nil, nil, errors.New("Format is required")
+		return nil, "", nil, nil, errors.New("format is required")
 	}
 
 	return addresses, format, startDate, endDate, nil

--- a/client/client.go
+++ b/client/client.go
@@ -19,8 +19,10 @@ import (
 	"gorm.io/gorm"
 )
 
-var DB *gorm.DB
-var GlobalCfg *config.Config
+var (
+	DB        *gorm.DB
+	GlobalCfg *config.Config
+)
 
 func setup() (*gorm.DB, *config.Config, int, string, error) {
 	argConfig, flagSet, svcPort, err := config.ParseArgs(os.Stderr, os.Args[1:])
@@ -206,7 +208,6 @@ var jsTimeFmt = "2006-01-02T15:04:05Z07:00"
 // @Router /events.csv [post]
 func GetTaxableEventsCSV(c *gin.Context) {
 	addresses, format, startDate, endDate, err := ParseTaxableEventsBody(c)
-
 	if err != nil {
 		return
 	}
@@ -249,7 +250,6 @@ func GetTaxableEventsCSV(c *gin.Context) {
 // @Router /events.json [post]
 func GetTaxableEventsJSON(c *gin.Context) {
 	addresses, format, startDate, endDate, err := ParseTaxableEventsBody(c)
-
 	if err != nil {
 		return
 	}
@@ -287,7 +287,6 @@ func GetTaxableEventsJSON(c *gin.Context) {
 func ParseTaxableEventsBody(c *gin.Context) ([]string, string, *time.Time, *time.Time, error) {
 	var requestBody TaxableEventsCSVRequest
 	err := c.BindJSON(&requestBody)
-
 	if err != nil {
 		// the error returned here has already been pushed to the context... I think.
 		c.AbortWithError(500, errors.New("error processing request body")) // nolint:staticcheck,errcheck

--- a/cmd/index.go
+++ b/cmd/index.go
@@ -489,7 +489,7 @@ func (idxr *Indexer) indexBlockEvents(wg *sync.WaitGroup, failedBlockHandler cor
 
 	config.Log.Infof("Indexing block events from block: %v to %v", startHeight, endHeight)
 
-	//TODO: Strip this out of the Osmosis module and make it generalized
+	// TODO: Strip this out of the Osmosis module and make it generalized
 	rpcClient := osmosis.URIClient{
 		Address: idxr.cl.Config.RPCAddr,
 		Client:  &http.Client{},
@@ -549,9 +549,9 @@ func (idxr *Indexer) indexBlockEvents(wg *sync.WaitGroup, failedBlockHandler cor
 		// Sleep for a bit to allow new blocks to be written to the chain, this allows us to continue the indexer run indefinitely
 		if currentHeight > lastKnownBlockHeight {
 			config.Log.Infof("Block %d has passed lastKnownBlockHeight, checking again", currentHeight)
-			//For loop catches both of the following
-			//whether we are going too fast and need to do multiple sleeps
-			//whether the lastKnownHeight was set a long time ago (as in at app start) and we just need to reset the value
+			// For loop catches both of the following
+			// whether we are going too fast and need to do multiple sleeps
+			// whether the lastKnownHeight was set a long time ago (as in at app start) and we just need to reset the value
 			for {
 				lastKnownBlockHeight, err = rpc.GetLatestBlockHeight(idxr.cl)
 				if err != nil {

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -66,7 +66,6 @@ var queryCmd = &cobra.Command{
 			parsedDate, err := time.Parse(expectedLayout, endDateStr)
 			if err != nil {
 				throwValidationErr(cmd, fmt.Sprintf("Invalid end date '%v'.", endDateStr))
-
 			}
 			endDate = &parsedDate
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -50,7 +50,7 @@ func init() {
 	rootCmd.PersistentFlags().Int64Var(&conf.Base.EndBlock, "base.end-block", -1, "block to stop indexing at (use -1 to index indefinitely")
 	rootCmd.PersistentFlags().BoolVar(&conf.Base.ReIndex, "base.reindex", false, "if true, this will re-attempt to index blocks we have already indexed (defaults to false)")
 	rootCmd.PersistentFlags().BoolVar(&conf.Base.PreventReattempts, "base.prevent-reattempts", false, "prevent reattempts of failed blocks.")
-	//block event indexing
+	// block event indexing
 	rootCmd.PersistentFlags().BoolVar(&conf.Base.BlockEventIndexingEnabled, "base.index-block-events", true, "enable block beginblocker and endblocker event indexing?")
 	rootCmd.PersistentFlags().Int64Var(&conf.Base.BlockEventsStartBlock, "base.block-events-start-block", 0, "block to start indexing block events at")
 	rootCmd.PersistentFlags().Int64Var(&conf.Base.BlockEventsEndBlock, "base.block-events-end-block", 0, "block to stop indexing block events at (use -1 to index indefinitely")
@@ -146,7 +146,6 @@ func bindFlags(cmd *cobra.Command, v *viper.Viper) {
 		if !f.Changed && v.IsSet(configName) {
 			val := v.Get(configName)
 			err := cmd.Flags().Set(f.Name, fmt.Sprintf("%v", val))
-
 			if err != nil {
 				log.Fatalf("Failed to bind config file value %v. Err: %v", configName, err)
 			}

--- a/cmd/update_denoms.go
+++ b/cmd/update_denoms.go
@@ -28,7 +28,6 @@ var updateDenomsCmd = &cobra.Command{
 
 func updateDenoms(cmd *cobra.Command, args []string) {
 	cfg, _, db, _, err := setup(conf)
-
 	if err != nil {
 		log.Fatalf("Error during application setup. Err: %v", err)
 	}

--- a/core/address.go
+++ b/core/address.go
@@ -19,8 +19,10 @@ import (
 )
 
 // consider not using globals
-var addressRegex *regexp.Regexp
-var addressPrefix string
+var (
+	addressRegex  *regexp.Regexp
+	addressPrefix string
+)
 
 // TODO query this list from the DB
 var baseChainPrefixes = []string{

--- a/core/address.go
+++ b/core/address.go
@@ -8,14 +8,14 @@ import (
 	"regexp"
 	"strings"
 
-	tx "github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules/tx"
+	"github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules/tx"
 	"github.com/DefiantLabs/cosmos-tax-cli/util"
 
 	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	cosmostypes "github.com/cosmos/cosmos-sdk/types"
-	legacybech32 "github.com/cosmos/cosmos-sdk/types/bech32/legacybech32" // nolint:staticcheck
+	"github.com/cosmos/cosmos-sdk/types/bech32/legacybech32" // nolint:staticcheck
 )
 
 // consider not using globals

--- a/core/block_events.go
+++ b/core/block_events.go
@@ -70,7 +70,7 @@ func ProcessRPCBlockEvents(blockResults *ctypes.ResultBlockResults) ([]eventType
 
 			// If err is not nil here, all handlers failed
 			if err != nil {
-				return nil, fmt.Errorf("Could not handle event type %s, all handlers failed", event.Type)
+				return nil, fmt.Errorf("could not handle event type %s, all handlers failed", event.Type)
 			}
 		}
 	}
@@ -101,7 +101,7 @@ func ProcessRPCBlockEvents(blockResults *ctypes.ResultBlockResults) ([]eventType
 
 			// If err is not nil here, all handlers failed
 			if err != nil {
-				return nil, fmt.Errorf("Could not handle event type %s, all handlers failed", event.Type)
+				return nil, fmt.Errorf("could not handle event type %s, all handlers failed", event.Type)
 			}
 		}
 	}

--- a/core/block_events.go
+++ b/core/block_events.go
@@ -10,8 +10,10 @@ import (
 	ctypes "github.com/tendermint/tendermint/rpc/core/types"
 )
 
-var beginBlockerEventTypeHandlers = map[string][]func() eventTypes.CosmosEvent{}
-var endBlockerEventTypeHandlers = map[string][]func() eventTypes.CosmosEvent{}
+var (
+	beginBlockerEventTypeHandlers = map[string][]func() eventTypes.CosmosEvent{}
+	endBlockerEventTypeHandlers   = map[string][]func() eventTypes.CosmosEvent{}
+)
 
 func ChainSpecificEndBlockerEventTypeHandlerBootstrap(chainID string) {
 	var chainSpecificEndBlockerEventTypeHandler map[string][]func() eventTypes.CosmosEvent
@@ -59,7 +61,7 @@ func ProcessRPCBlockEvents(blockResults *ctypes.ResultBlockResults) ([]eventType
 					config.Log.Debug(fmt.Sprintf("[Block: %v] Cosmos Block EndBlocker event of known type: %s. Handler failed", blockResults.Height, event.Type), err)
 					continue
 				}
-				var relevantData = cosmosEventHandler.ParseRelevantData()
+				relevantData := cosmosEventHandler.ParseRelevantData()
 
 				taxableEvents = append(taxableEvents, relevantData...)
 
@@ -90,7 +92,7 @@ func ProcessRPCBlockEvents(blockResults *ctypes.ResultBlockResults) ([]eventType
 					config.Log.Debug(fmt.Sprintf("[Block: %v] Cosmos Block EndBlocker event of known type: %s. Handler failed", blockResults.Height, event.Type), err)
 					continue
 				}
-				var relevantData = cosmosEventHandler.ParseRelevantData()
+				relevantData := cosmosEventHandler.ParseRelevantData()
 
 				taxableEvents = append(taxableEvents, relevantData...)
 

--- a/core/block_events.go
+++ b/core/block_events.go
@@ -6,7 +6,6 @@ import (
 	"github.com/DefiantLabs/cosmos-tax-cli/config"
 	eventTypes "github.com/DefiantLabs/cosmos-tax-cli/cosmos/events"
 	"github.com/DefiantLabs/cosmos-tax-cli/cosmoshub"
-	cosmoshubTypes "github.com/DefiantLabs/cosmos-tax-cli/cosmoshub"
 	osmosisTypes "github.com/DefiantLabs/cosmos-tax-cli/osmosis"
 	ctypes "github.com/tendermint/tendermint/rpc/core/types"
 )
@@ -17,7 +16,7 @@ var endBlockerEventTypeHandlers = map[string][]func() eventTypes.CosmosEvent{}
 func ChainSpecificEndBlockerEventTypeHandlerBootstrap(chainID string) {
 	var chainSpecificEndBlockerEventTypeHandler map[string][]func() eventTypes.CosmosEvent
 	if chainID == cosmoshub.ChainID {
-		chainSpecificEndBlockerEventTypeHandler = cosmoshubTypes.EndBlockerEventTypeHandlers
+		chainSpecificEndBlockerEventTypeHandler = cosmoshub.EndBlockerEventTypeHandlers
 	}
 	for key, value := range chainSpecificEndBlockerEventTypeHandler {
 		if list, ok := endBlockerEventTypeHandlers[key]; ok {

--- a/core/tx.go
+++ b/core/tx.go
@@ -199,7 +199,7 @@ func ProcessRPCBlockByHeightTXs(db *gorm.DB, cl *client.ChainClient, blockResult
 
 	blockTime := &blockResults.Block.Time
 	blockTimeStr := blockTime.Format(time.RFC3339)
-	var currTxDbWrappers = make([]dbTypes.TxDBWrapper, len(blockResults.Block.Txs))
+	currTxDbWrappers := make([]dbTypes.TxDBWrapper, len(blockResults.Block.Txs))
 
 	for txIdx, tendermintTx := range blockResults.Block.Txs {
 		txResult := resultBlockRes.TxsResults[txIdx]
@@ -286,7 +286,7 @@ func ProcessRPCBlockByHeightTXs(db *gorm.DB, cl *client.ChainClient, blockResult
 
 // ProcessRPCTXs - Given an RPC response, build out the more specific data used by the parser.
 func ProcessRPCTXs(db *gorm.DB, txEventResp *cosmosTx.GetTxsEventResponse) ([]dbTypes.TxDBWrapper, *time.Time, error) {
-	var currTxDbWrappers = make([]dbTypes.TxDBWrapper, len(txEventResp.Txs))
+	currTxDbWrappers := make([]dbTypes.TxDBWrapper, len(txEventResp.Txs))
 	var blockTime *time.Time
 
 	for txIdx := range txEventResp.Txs {
@@ -431,10 +431,10 @@ func ProcessTx(db *gorm.DB, tx txtypes.MergedTx) (txDBWapper dbTypes.TxDBWrapper
 				currMessage.MessageType = currMessageType
 				currMessageDBWrapper.Message = currMessage
 
-				var relevantData = cosmosMessage.ParseRelevantData()
+				relevantData := cosmosMessage.ParseRelevantData()
 
 				if len(relevantData) > 0 {
-					var taxableTxs = make([]dbTypes.TaxableTxDBWrapper, len(relevantData))
+					taxableTxs := make([]dbTypes.TaxableTxDBWrapper, len(relevantData))
 					for i, v := range relevantData {
 						if v.AmountSent != nil {
 							taxableTxs[i].TaxableTx.AmountSent = util.ToNumeric(v.AmountSent)

--- a/core/tx.go
+++ b/core/tx.go
@@ -18,8 +18,7 @@ import (
 	"github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules/ibc"
 	"github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules/slashing"
 	"github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules/staking"
-	"github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules/tx"
-	txTypes "github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules/tx"
+	txtypes "github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules/tx"
 	"github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules/vesting"
 	"github.com/DefiantLabs/cosmos-tax-cli/cosmwasm/modules/wasm"
 	dbTypes "github.com/DefiantLabs/cosmos-tax-cli/db"
@@ -40,18 +39,18 @@ import (
 )
 
 // Unmarshal JSON to a particular type. There can be more than one handler for each type.
-var messageTypeHandler = map[string][]func() txTypes.CosmosMessage{
-	bank.MsgSend:                                {func() txTypes.CosmosMessage { return &bank.WrapperMsgSend{} }},
-	bank.MsgMultiSend:                           {func() txTypes.CosmosMessage { return &bank.WrapperMsgMultiSend{} }},
-	distribution.MsgWithdrawDelegatorReward:     {func() txTypes.CosmosMessage { return &distribution.WrapperMsgWithdrawDelegatorReward{} }},
-	distribution.MsgWithdrawValidatorCommission: {func() txTypes.CosmosMessage { return &distribution.WrapperMsgWithdrawValidatorCommission{} }},
-	distribution.MsgFundCommunityPool:           {func() txTypes.CosmosMessage { return &distribution.WrapperMsgFundCommunityPool{} }},
-	gov.MsgDeposit:                              {func() txTypes.CosmosMessage { return &gov.WrapperMsgDeposit{} }},
-	gov.MsgSubmitProposal:                       {func() txTypes.CosmosMessage { return &gov.WrapperMsgSubmitProposal{} }},
-	staking.MsgDelegate:                         {func() txTypes.CosmosMessage { return &staking.WrapperMsgDelegate{} }},
-	staking.MsgUndelegate:                       {func() txTypes.CosmosMessage { return &staking.WrapperMsgUndelegate{} }},
-	staking.MsgBeginRedelegate:                  {func() txTypes.CosmosMessage { return &staking.WrapperMsgBeginRedelegate{} }},
-	ibc.MsgTransfer:                             {func() txTypes.CosmosMessage { return &ibc.WrapperMsgTransfer{} }},
+var messageTypeHandler = map[string][]func() txtypes.CosmosMessage{
+	bank.MsgSend:                                {func() txtypes.CosmosMessage { return &bank.WrapperMsgSend{} }},
+	bank.MsgMultiSend:                           {func() txtypes.CosmosMessage { return &bank.WrapperMsgMultiSend{} }},
+	distribution.MsgWithdrawDelegatorReward:     {func() txtypes.CosmosMessage { return &distribution.WrapperMsgWithdrawDelegatorReward{} }},
+	distribution.MsgWithdrawValidatorCommission: {func() txtypes.CosmosMessage { return &distribution.WrapperMsgWithdrawValidatorCommission{} }},
+	distribution.MsgFundCommunityPool:           {func() txtypes.CosmosMessage { return &distribution.WrapperMsgFundCommunityPool{} }},
+	gov.MsgDeposit:                              {func() txtypes.CosmosMessage { return &gov.WrapperMsgDeposit{} }},
+	gov.MsgSubmitProposal:                       {func() txtypes.CosmosMessage { return &gov.WrapperMsgSubmitProposal{} }},
+	staking.MsgDelegate:                         {func() txtypes.CosmosMessage { return &staking.WrapperMsgDelegate{} }},
+	staking.MsgUndelegate:                       {func() txtypes.CosmosMessage { return &staking.WrapperMsgUndelegate{} }},
+	staking.MsgBeginRedelegate:                  {func() txtypes.CosmosMessage { return &staking.WrapperMsgBeginRedelegate{} }},
+	ibc.MsgTransfer:                             {func() txtypes.CosmosMessage { return &ibc.WrapperMsgTransfer{} }},
 }
 
 // These messages are ignored for tax purposes.
@@ -125,7 +124,7 @@ var messageTypeIgnorer = map[string]interface{}{
 // Merge the chain specific message type handlers into the core message type handler map.
 // Chain specific handlers will be registered BEFORE any generic handlers.
 func ChainSpecificMessageTypeHandlerBootstrap(chainID string) {
-	var chainSpecificMessageTpeHandler map[string][]func() txTypes.CosmosMessage
+	var chainSpecificMessageTpeHandler map[string][]func() txtypes.CosmosMessage
 	if chainID == osmosis.ChainID {
 		chainSpecificMessageTpeHandler = osmosis.MessageTypeHandler
 	}
@@ -139,20 +138,20 @@ func ChainSpecificMessageTypeHandlerBootstrap(chainID string) {
 }
 
 // ParseCosmosMessageJSON - Parse a SINGLE Cosmos Message into the appropriate type.
-func ParseCosmosMessage(message types.Msg, log txTypes.LogMessage) (txTypes.CosmosMessage, string, error) {
+func ParseCosmosMessage(message types.Msg, log txtypes.LogMessage) (txtypes.CosmosMessage, string, error) {
 	var ok bool
 	var err error
-	var msgHandler txTypes.CosmosMessage
-	var handlerList []func() txTypes.CosmosMessage
+	var msgHandler txtypes.CosmosMessage
+	var handlerList []func() txtypes.CosmosMessage
 
 	// Figure out what type of Message this is based on the '@type' field that is included
 	// in every Cosmos Message (can be seen in raw JSON for any cosmos transaction).
-	cosmosMessage := txTypes.Message{}
+	cosmosMessage := txtypes.Message{}
 	cosmosMessage.Type = types.MsgTypeURL(message)
 
 	// So far we only parsed the '@type' field. Now we get a struct for that specific type.
 	if handlerList, ok = messageTypeHandler[cosmosMessage.Type]; !ok {
-		return nil, cosmosMessage.Type, txTypes.ErrUnknownMessage
+		return nil, cosmosMessage.Type, txtypes.ErrUnknownMessage
 	}
 
 	for _, handlerFunc := range handlerList {
@@ -170,19 +169,19 @@ func ParseCosmosMessage(message types.Msg, log txTypes.LogMessage) (txTypes.Cosm
 	return msgHandler, cosmosMessage.Type, err
 }
 
-func toAttributes(attrs []types.Attribute) []txTypes.Attribute {
-	list := []txTypes.Attribute{}
+func toAttributes(attrs []types.Attribute) []txtypes.Attribute {
+	list := []txtypes.Attribute{}
 	for _, attr := range attrs {
-		lma := txTypes.Attribute{Key: attr.Key, Value: attr.Value}
+		lma := txtypes.Attribute{Key: attr.Key, Value: attr.Value}
 		list = append(list, lma)
 	}
 
 	return list
 }
 
-func toEvents(msgEvents types.StringEvents) (list []txTypes.LogMessageEvent) {
+func toEvents(msgEvents types.StringEvents) (list []txtypes.LogMessageEvent) {
 	for _, evt := range msgEvents {
-		lme := tx.LogMessageEvent{Type: evt.Type, Attributes: toAttributes(evt.Attributes)}
+		lme := txtypes.LogMessageEvent{Type: evt.Type, Attributes: toAttributes(evt.Attributes)}
 		list = append(list, lme)
 	}
 
@@ -206,11 +205,11 @@ func ProcessRPCBlockByHeightTXs(db *gorm.DB, cl *client.ChainClient, blockResult
 		txResult := resultBlockRes.TxsResults[txIdx]
 
 		// Indexer types only used by the indexer app (similar to the cosmos types)
-		var indexerMergedTx txTypes.MergedTx
-		var indexerTx txTypes.IndexerTx
-		var txBody txTypes.Body
+		var indexerMergedTx txtypes.MergedTx
+		var indexerTx txtypes.IndexerTx
+		var txBody txtypes.Body
 		var currMessages []types.Msg
-		var currLogMsgs []tx.LogMessage
+		var currLogMsgs []txtypes.LogMessage
 
 		txDecoder := cl.Codec.TxConfig.TxDecoder()
 		txBasic, err := txDecoder(tendermintTx)
@@ -245,7 +244,7 @@ func ProcessRPCBlockByHeightTXs(db *gorm.DB, cl *client.ChainClient, blockResult
 					msgEvents = logs[msgIdx].Events
 				}
 
-				currTxLog := tx.LogMessage{
+				currTxLog := txtypes.LogMessage{
 					MessageIndex: msgIdx,
 					Events:       toEvents(msgEvents),
 				}
@@ -258,7 +257,7 @@ func ProcessRPCBlockByHeightTXs(db *gorm.DB, cl *client.ChainClient, blockResult
 		txBody.Messages = currMessages
 		indexerTx.Body = txBody
 		txHash := tendermintTx.Hash()
-		indexerTxResp := tx.Response{
+		indexerTxResp := txtypes.Response{
 			TxHash:    b64.StdEncoding.EncodeToString(txHash),
 			Height:    fmt.Sprintf("%d", blockResults.Block.Height),
 			TimeStamp: blockTimeStr,
@@ -292,11 +291,11 @@ func ProcessRPCTXs(db *gorm.DB, txEventResp *cosmosTx.GetTxsEventResponse) ([]db
 
 	for txIdx := range txEventResp.Txs {
 		// Indexer types only used by the indexer app (similar to the cosmos types)
-		var indexerMergedTx txTypes.MergedTx
-		var indexerTx txTypes.IndexerTx
-		var txBody txTypes.Body
+		var indexerMergedTx txtypes.MergedTx
+		var indexerTx txtypes.IndexerTx
+		var txBody txtypes.Body
 		var currMessages []types.Msg
-		var currLogMsgs []tx.LogMessage
+		var currLogMsgs []txtypes.LogMessage
 		currTx := txEventResp.Txs[txIdx]
 		currTxResp := txEventResp.TxResponses[txIdx]
 
@@ -308,7 +307,7 @@ func ProcessRPCTXs(db *gorm.DB, txEventResp *cosmosTx.GetTxsEventResponse) ([]db
 				currMessages = append(currMessages, msg)
 				if len(currTxResp.Logs) >= msgIdx+1 {
 					msgEvents := currTxResp.Logs[msgIdx].Events
-					currTxLog := tx.LogMessage{
+					currTxLog := txtypes.LogMessage{
 						MessageIndex: msgIdx,
 						Events:       toEvents(msgEvents),
 					}
@@ -327,7 +326,7 @@ func ProcessRPCTXs(db *gorm.DB, txEventResp *cosmosTx.GetTxsEventResponse) ([]db
 		txBody.Messages = currMessages
 		indexerTx.Body = txBody
 
-		indexerTxResp := tx.Response{
+		indexerTxResp := txtypes.Response{
 			TxHash:    currTxResp.TxHash,
 			Height:    fmt.Sprintf("%d", currTxResp.Height),
 			TimeStamp: currTxResp.Timestamp,
@@ -386,7 +385,7 @@ func AnalyzeSwaps() {
 	fmt.Printf("Profit (OSMO): %.10f, days: %f\n", profit, latestTime.Sub(earliestTime).Hours()/24)
 }
 
-func ProcessTx(db *gorm.DB, tx txTypes.MergedTx) (txDBWapper dbTypes.TxDBWrapper, txTime time.Time, err error) {
+func ProcessTx(db *gorm.DB, tx txtypes.MergedTx) (txDBWapper dbTypes.TxDBWrapper, txTime time.Time, err error) {
 	txTime, err = time.Parse(time.RFC3339, tx.TxResponse.TimeStamp)
 	if err != nil {
 		config.Log.Error("Error parsing tx timestamp.", err)
@@ -406,13 +405,13 @@ func ProcessTx(db *gorm.DB, tx txTypes.MergedTx) (txDBWapper dbTypes.TxDBWrapper
 
 			// Get the message log that corresponds to the current message
 			var currMessageDBWrapper dbTypes.MessageDBWrapper
-			messageLog := txTypes.GetMessageLogForIndex(tx.TxResponse.Log, messageIndex)
+			messageLog := txtypes.GetMessageLogForIndex(tx.TxResponse.Log, messageIndex)
 			cosmosMessage, msgType, err := ParseCosmosMessage(message, *messageLog)
 			if err != nil {
 				currMessageType.MessageType = msgType
 				currMessage.MessageType = currMessageType
 				currMessageDBWrapper.Message = currMessage
-				if err != txTypes.ErrUnknownMessage {
+				if err != txtypes.ErrUnknownMessage {
 					// What should we do here? This is an actual error during parsing
 					config.Log.Error(fmt.Sprintf("[Block: %v] ParseCosmosMessage failed for msg of type '%v'.", tx.TxResponse.Height, msgType), err)
 					config.Log.Error(fmt.Sprint(messageLog))

--- a/cosmos/modules/bank/types.go
+++ b/cosmos/modules/bank/types.go
@@ -85,7 +85,7 @@ func (sf *WrapperMsgMultiSend) HandleMsg(msgType string, msg sdk.Msg, log *txMod
 				return fmt.Errorf("error processing MultiSend, inputs and outputs mismatch for denom %v, send %s != received %s", coin, amountSent, amountReceived)
 			}
 		} else {
-			return fmt.Errorf("error processing MultiSend, sent denom %v does not appear in recieved coins", coin)
+			return fmt.Errorf("error processing MultiSend, sent denom %v does not appear in received coins", coin)
 		}
 	}
 
@@ -106,7 +106,7 @@ func (sf *WrapperMsgMultiSend) String() string {
 }
 
 func (sf *WrapperMsgSend) ParseRelevantData() []parsingTypes.MessageRelevantInformation {
-	var relevantData []parsingTypes.MessageRelevantInformation = make([]parsingTypes.MessageRelevantInformation, len(sf.CosmosMsgSend.Amount))
+	relevantData := make([]parsingTypes.MessageRelevantInformation, len(sf.CosmosMsgSend.Amount))
 
 	for i, v := range sf.CosmosMsgSend.Amount {
 		var currRelevantData parsingTypes.MessageRelevantInformation

--- a/cosmos/modules/distribution/types.go
+++ b/cosmos/modules/distribution/types.go
@@ -133,7 +133,7 @@ func (sf *WrapperMsgWithdrawDelegatorReward) HandleMsg(msgType string, msg stdTy
 }
 
 func (sf *WrapperMsgFundCommunityPool) ParseRelevantData() []parsingTypes.MessageRelevantInformation {
-	var relevantData []parsingTypes.MessageRelevantInformation = make([]parsingTypes.MessageRelevantInformation, len(sf.Funds))
+	relevantData := make([]parsingTypes.MessageRelevantInformation, len(sf.Funds))
 
 	for i, v := range sf.Funds {
 		relevantData[i].AmountSent = v.Amount.BigInt()
@@ -146,7 +146,7 @@ func (sf *WrapperMsgFundCommunityPool) ParseRelevantData() []parsingTypes.Messag
 
 func (sf *WrapperMsgWithdrawValidatorCommission) ParseRelevantData() []parsingTypes.MessageRelevantInformation {
 	if sf.CoinsReceived.IsNil() {
-		var relevantData []parsingTypes.MessageRelevantInformation = make([]parsingTypes.MessageRelevantInformation, len(sf.MultiCoinsReceived))
+		relevantData := make([]parsingTypes.MessageRelevantInformation, len(sf.MultiCoinsReceived))
 
 		for i, v := range sf.MultiCoinsReceived {
 			relevantData[i] = parsingTypes.MessageRelevantInformation{

--- a/cosmos/modules/gov/types.go
+++ b/cosmos/modules/gov/types.go
@@ -36,7 +36,7 @@ type WrapperMsgDeposit struct {
 }
 
 func (sf *WrapperMsgSubmitProposal) ParseRelevantData() []parsingTypes.MessageRelevantInformation {
-	var relevantData []parsingTypes.MessageRelevantInformation = make([]parsingTypes.MessageRelevantInformation, len(sf.CosmosMsgSubmitProposal.InitialDeposit))
+	relevantData := make([]parsingTypes.MessageRelevantInformation, len(sf.CosmosMsgSubmitProposal.InitialDeposit))
 
 	for i, v := range sf.CosmosMsgSubmitProposal.InitialDeposit {
 		var currRelevantData parsingTypes.MessageRelevantInformation
@@ -58,7 +58,7 @@ func (sf *WrapperMsgSubmitProposal) ParseRelevantData() []parsingTypes.MessageRe
 }
 
 func (sf *WrapperMsgDeposit) ParseRelevantData() []parsingTypes.MessageRelevantInformation {
-	var relevantData []parsingTypes.MessageRelevantInformation = make([]parsingTypes.MessageRelevantInformation, len(sf.CosmosMsgDeposit.Amount))
+	relevantData := make([]parsingTypes.MessageRelevantInformation, len(sf.CosmosMsgDeposit.Amount))
 
 	for i, v := range sf.CosmosMsgDeposit.Amount {
 		var currRelevantData parsingTypes.MessageRelevantInformation

--- a/cosmos/modules/tx/logic.go
+++ b/cosmos/modules/tx/logic.go
@@ -96,7 +96,7 @@ func ParseTransferEvent(evt LogMessageEvent) ([]TransferEvent, error) {
 			} else {
 				return nil, errInvalidTransfer
 			}
-		} else if i%3 == 0 { //every third attr should be "recipient"
+		} else if i%3 == 0 { // every third attr should be "recipient"
 			return nil, errInvalidTransfer
 		}
 	}

--- a/cosmoshub/handlers.go
+++ b/cosmoshub/handlers.go
@@ -2,5 +2,5 @@ package cosmoshub
 
 import tendermintHandlers "github.com/DefiantLabs/cosmos-tax-cli/tendermint"
 
-// Extend these using an init func to setup CosmosHub end blocker handlers if we want more functionality
+// EndBlockerEventTypeHandlers should be extended using these and an init func to set up CosmosHub end blocker handlers if we want more functionality.
 var EndBlockerEventTypeHandlers = tendermintHandlers.EndBlockerEventTypeHandlers

--- a/csv/parser.go
+++ b/csv/parser.go
@@ -48,7 +48,7 @@ func GetParser(parserKey string) parsers.Parser {
 func ParseForAddress(addresses []string, startDate, endDate *time.Time, pgSQL *gorm.DB, parserKey string, cfg config.Config) ([]parsers.CsvRow, []string, error) {
 	parser := GetParser(parserKey)
 	if parser == nil {
-		return nil, nil, errors.New("Invalid parser key")
+		return nil, nil, errors.New("invalid parser key")
 	}
 	parser.InitializeParsingGroups()
 

--- a/csv/parsers/accointing/accointing.go
+++ b/csv/parsers/accointing/accointing.go
@@ -151,8 +151,10 @@ func (p *Parser) GetRows(address string, startDate, endDate *time.Time) []parser
 }
 
 func (p Parser) GetHeaders() []string {
-	return []string{"transactionType", "date", "inBuyAmount", "inBuyAsset", "outSellAmount", "outSellAsset",
-		"feeAmount (optional)", "feeAsset (optional)", "classification (optional)", "operationId (optional)", "comments (optional)"}
+	return []string{
+		"transactionType", "date", "inBuyAmount", "inBuyAsset", "outSellAmount", "outSellAsset",
+		"feeAmount (optional)", "feeAsset (optional)", "classification (optional)", "operationId (optional)", "comments (optional)",
+	}
 }
 
 // HandleFees:

--- a/csv/parsers/koinly/koinly.go
+++ b/csv/parsers/koinly/koinly.go
@@ -219,8 +219,10 @@ func mapUnsupportedCoints(rows []Row) {
 }
 
 func (p Parser) GetHeaders() []string {
-	return []string{"Date", "Sent Amount", "Sent Currency", "Received Amount", "Received Currency", "Fee Amount", "Fee Currency",
-		"Net Worth Amount", "Net Worth Currency", "Label", "Description", "TxHash"}
+	return []string{
+		"Date", "Sent Amount", "Sent Currency", "Received Amount", "Received Currency", "Fee Amount", "Fee Currency",
+		"Net Worth Amount", "Net Worth Currency", "Label", "Description", "TxHash",
+	}
 }
 
 // HandleFees:

--- a/csv/parsers/koinly/types.go
+++ b/csv/parsers/koinly/types.go
@@ -59,7 +59,9 @@ const (
 )
 
 func (at Label) String() string {
-	return [...]string{"", "gift", "lost", "cost", "margin fee", "realized gain", "stake",
+	return [...]string{
+		"", "gift", "lost", "cost", "margin fee", "realized gain", "stake",
 		"airdrop", "fork", "mining", "reward", "income", "loan interest", "unstake",
-		"swap", "liquidity in", "liquidity out"}[at]
+		"swap", "liquidity in", "liquidity out",
+	}[at]
 }

--- a/csv/parsers/osmosis.go
+++ b/csv/parsers/osmosis.go
@@ -17,7 +17,7 @@ var IsOsmosisExit = map[string]bool{
 	gamm.MsgExitPool:                true,
 }
 
-// Guard for adding messages to the group
+// IsOsmosisLpTxGroup is used as a guard for adding messages to the group.
 var IsOsmosisLpTxGroup = make(map[string]bool)
 
 func init() {

--- a/csv/parsers/parsers.go
+++ b/csv/parsers/parsers.go
@@ -2,7 +2,7 @@ package parsers
 
 import "github.com/DefiantLabs/cosmos-tax-cli/db"
 
-// Check in your parsers here
+// Parsers should be used to check in your parsers.
 var Parsers map[string]bool
 
 func init() {

--- a/csv/parsers/taxbit/taxbit.go
+++ b/csv/parsers/taxbit/taxbit.go
@@ -149,9 +149,11 @@ func (p *Parser) GetRows(address string, startDate, endDate *time.Time) []parser
 }
 
 func (p Parser) GetHeaders() []string {
-	return []string{"Date and Time", "Transaction Type", "Sent Quantity", "Sent Currency", "Sending Source",
+	return []string{
+		"Date and Time", "Transaction Type", "Sent Quantity", "Sent Currency", "Sending Source",
 		"Received Quantity", "Received Currency", "Receiving Destination", "Fee", "Fee Currency", "Exchange Transaction ID",
-		"Blockchain Transaction Hash"}
+		"Blockchain Transaction Hash",
+	}
 }
 
 // HandleFees:

--- a/db/denoms.go
+++ b/db/denoms.go
@@ -11,8 +11,10 @@ import (
 	"gorm.io/gorm"
 )
 
-var CachedDenomUnits []DenomUnit
-var denomCacheMutex sync.Mutex
+var (
+	CachedDenomUnits []DenomUnit
+	denomCacheMutex  sync.Mutex
+)
 
 func CacheDenoms(db *gorm.DB) {
 	var denomUnits []DenomUnit

--- a/db/events.go
+++ b/db/events.go
@@ -63,7 +63,7 @@ func IndexBlockEvents(db *gorm.DB, dryRun bool, blockHeight int64, blockTime tim
 
 		awaitingInsert := dbEvents[i:batchEnd]
 
-		//Only way this can happen is if i == batchEnd
+		// Only way this can happen is if i == batchEnd
 		if len(awaitingInsert) == 0 {
 			awaitingInsert = []TaxableEvent{dbEvents[i]}
 		}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -33,7 +33,7 @@ services:
 
   indexer:
     restart: "no"
-    image: cosmos-cli:local
+    image: ghcr.io/defiantlabs/cosmos-tax-cli:main
     user: defiant
     stop_grace_period: 10s
     volumes:
@@ -57,7 +57,7 @@ services:
       --log.pretty = true \
       --log.level = debug \
       --base.index-chain = false \
-      --base.start-block 2723300 \
+      --base.start-block 2723462 \
       --base.end-block 2723464 \
       --base.index-rewards = true \
       --base.rewards-start-block 4535620 \

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -33,7 +33,7 @@ services:
 
   indexer:
     restart: "no"
-    image: ghcr.io/defiantlabs/cosmos-tax-cli:main
+    image: cosmos-cli:local
     user: defiant
     stop_grace_period: 10s
     volumes:
@@ -57,7 +57,7 @@ services:
       --log.pretty = true \
       --log.level = debug \
       --base.index-chain = false \
-      --base.start-block 2723462 \
+      --base.start-block 2723300 \
       --base.end-block 2723464 \
       --base.index-rewards = true \
       --base.rewards-start-block 4535620 \

--- a/osmosis/events/incentives/types.go
+++ b/osmosis/events/incentives/types.go
@@ -43,7 +43,7 @@ func (sf *WrapperBlockDistribution) HandleEvent(eventType string, event abciType
 		sf.ReceiverAddress = receiverAddr
 		sf.RewardsReceived = coins
 	} else {
-		return errors.New("Rewards received or address were not present")
+		return errors.New("rewards received or address were not present")
 	}
 
 	return nil

--- a/osmosis/events/incentives/types.go
+++ b/osmosis/events/incentives/types.go
@@ -22,7 +22,6 @@ func (sf *WrapperBlockDistribution) GetType() string {
 }
 
 func (sf *WrapperBlockDistribution) HandleEvent(eventType string, event abciTypes.Event) error {
-
 	var receiverAddr string
 	var receiverAmount string
 

--- a/osmosis/handlers.go
+++ b/osmosis/handlers.go
@@ -10,7 +10,7 @@ import (
 	"github.com/DefiantLabs/cosmos-tax-cli/osmosis/modules/poolmanager"
 )
 
-// Unmarshal JSON to a particular type.
+// MessageTypeHandler is used to unmarshal JSON to a particular type.
 var MessageTypeHandler = map[string][]func() txTypes.CosmosMessage{
 	gamm.MsgSwapExactAmountIn:         {func() txTypes.CosmosMessage { return &gamm.WrapperMsgSwapExactAmountIn{} }, func() txTypes.CosmosMessage { return &gamm.WrapperMsgSwapExactAmountIn2{} }, func() txTypes.CosmosMessage { return &gamm.WrapperMsgSwapExactAmountIn3{} }, func() txTypes.CosmosMessage { return &gamm.WrapperMsgSwapExactAmountIn4{} }},
 	gamm.MsgSwapExactAmountOut:        {func() txTypes.CosmosMessage { return &gamm.WrapperMsgSwapExactAmountOut{} }},
@@ -25,7 +25,7 @@ var MessageTypeHandler = map[string][]func() txTypes.CosmosMessage{
 	poolmanager.MsgSwapExactAmountOut: {func() txTypes.CosmosMessage { return &poolmanager.WrapperMsgSwapExactAmountOut{} }},
 }
 
-// Extend these using an init func to setup CosmosHub end blocker handlers if we want more functionality
+// BeginBlockerEventTypeHandlers should be extended using these and an init func to set up CosmosHub end blocker handlers if we want more functionality.
 var BeginBlockerEventTypeHandlers = map[string][]func() eventTypes.CosmosEvent{
 	events.BlockEventDistribution: {func() eventTypes.CosmosEvent { return &incentivesEventTypes.WrapperBlockDistribution{} }},
 }

--- a/osmosis/helpers.go
+++ b/osmosis/helpers.go
@@ -141,6 +141,7 @@ func unmarshalResponseBytes(responseBytes []byte, expectedID types.JSONRPCIntID,
 
 	return result, nil
 }
+
 func (c *URIClient) DoBlockSearch(ctx context.Context, query string, page, perPage *int, orderBy string) (*ctypes.ResultBlockSearch, error) {
 	result := new(ctypes.ResultBlockSearch)
 	params := map[string]interface{}{

--- a/osmosis/modules/gamm/types.go
+++ b/osmosis/modules/gamm/types.go
@@ -153,7 +153,7 @@ type WrapperMsgCreatePool struct {
 	OsmosisMsgCreatePool *osmosisOldTypes.MsgCreatePool
 	CoinsSpent           []sdk.Coin
 	GammCoinsReceived    sdk.Coin
-	OtherCoinsReceived   []coinReceived //e.g. from claims module (airdrops)
+	OtherCoinsReceived   []coinReceived // e.g. from claims module (airdrops)
 }
 
 type coinReceived struct {
@@ -568,10 +568,9 @@ func (sf *WrapperMsgSwapExactAmountOut) HandleMsg(msgType string, msg sdk.Msg, l
 		tokenInDenom := sf.OsmosisMsgSwapExactAmountOut.TokenInDenom()
 
 		for _, evt := range transferEvt.Attributes {
-			//Get the first amount that matches the token in denom
+			// Get the first amount that matches the token in denom
 			if evt.Key == "amount" {
 				tokenIn, err := sdk.ParseCoinNormalized(evt.Value)
-
 				if err != nil {
 					return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
 				}
@@ -592,7 +591,6 @@ func (sf *WrapperMsgSwapExactAmountOut) HandleMsg(msgType string, msg sdk.Msg, l
 
 		tokenOutStr := txModule.GetLastValueForAttribute("amount", transferEvt)
 		tokenOut, err := sdk.ParseCoinNormalized(tokenOutStr)
-
 		if err != nil {
 			return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
 		}
@@ -1169,7 +1167,6 @@ func (sf *WrapperMsgExitSwapShareAmountIn2) HandleMsg(msgType string, msg sdk.Ms
 		return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
 	}
 	multiTokensOut, err := sdk.ParseCoinsNormalized(tokensOut)
-
 	if err != nil {
 		return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
 	}
@@ -1184,13 +1181,11 @@ func (sf *WrapperMsgExitSwapShareAmountIn2) HandleMsg(msgType string, msg sdk.Ms
 		tokenSwappedIn := txModule.GetValueForAttribute(gammTypes.AttributeKeyTokensIn, &tokenSwappedEvent)
 		tokenSwappedOut := txModule.GetValueForAttribute(gammTypes.AttributeKeyTokensOut, &tokenSwappedEvent)
 		parsedTokensSwappedIn, err := sdk.ParseCoinNormalized(tokenSwappedIn)
-
 		if err != nil {
 			return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
 		}
 
 		parsedTokensSwappedOut, err := sdk.ParseCoinNormalized(tokenSwappedOut)
-
 		if err != nil {
 			return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
 		}
@@ -1372,7 +1367,7 @@ type ArbitrageTx struct {
 }
 
 func (sf *WrapperMsgSwapExactAmountIn) ParseRelevantData() []parsingTypes.MessageRelevantInformation {
-	var relevantData = make([]parsingTypes.MessageRelevantInformation, 1)
+	relevantData := make([]parsingTypes.MessageRelevantInformation, 1)
 	relevantData[0] = parsingTypes.MessageRelevantInformation{
 		AmountSent:           sf.TokenIn.Amount.BigInt(),
 		DenominationSent:     sf.TokenIn.Denom,
@@ -1389,7 +1384,7 @@ func (sf *WrapperMsgSwapExactAmountIn2) ParseRelevantData() []parsingTypes.Messa
 }
 
 func (sf *WrapperMsgSwapExactAmountOut) ParseRelevantData() []parsingTypes.MessageRelevantInformation {
-	var relevantData = make([]parsingTypes.MessageRelevantInformation, 1)
+	relevantData := make([]parsingTypes.MessageRelevantInformation, 1)
 	relevantData[0] = parsingTypes.MessageRelevantInformation{
 		AmountSent:           sf.TokenIn.Amount.BigInt(),
 		DenominationSent:     sf.TokenIn.Denom,
@@ -1402,7 +1397,7 @@ func (sf *WrapperMsgSwapExactAmountOut) ParseRelevantData() []parsingTypes.Messa
 }
 
 func (sf *WrapperMsgJoinSwapExternAmountIn) ParseRelevantData() []parsingTypes.MessageRelevantInformation {
-	var relevantData = make([]parsingTypes.MessageRelevantInformation, 1)
+	relevantData := make([]parsingTypes.MessageRelevantInformation, 1)
 	relevantData[0] = parsingTypes.MessageRelevantInformation{
 		AmountSent:           sf.TokenIn.Amount.BigInt(),
 		DenominationSent:     sf.TokenIn.Denom,
@@ -1415,7 +1410,7 @@ func (sf *WrapperMsgJoinSwapExternAmountIn) ParseRelevantData() []parsingTypes.M
 }
 
 func (sf *WrapperMsgJoinSwapShareAmountOut) ParseRelevantData() []parsingTypes.MessageRelevantInformation {
-	var relevantData = make([]parsingTypes.MessageRelevantInformation, 1)
+	relevantData := make([]parsingTypes.MessageRelevantInformation, 1)
 	relevantData[0] = parsingTypes.MessageRelevantInformation{
 		AmountSent:           sf.TokenIn.Amount.BigInt(),
 		DenominationSent:     sf.TokenIn.Denom,
@@ -1429,7 +1424,7 @@ func (sf *WrapperMsgJoinSwapShareAmountOut) ParseRelevantData() []parsingTypes.M
 
 func (sf *WrapperMsgJoinPool) ParseRelevantData() []parsingTypes.MessageRelevantInformation {
 	// need to make a relevant data block for all Tokens sent to the pool since JoinPool can use 1 or both tokens used in the pool
-	var relevantData = make([]parsingTypes.MessageRelevantInformation, len(sf.TokensIn))
+	relevantData := make([]parsingTypes.MessageRelevantInformation, len(sf.TokensIn))
 
 	// figure out how many gams per token
 	nthGamms, remainderGamms := calcNthGams(sf.TokenOut.Amount.BigInt(), len(sf.TokensIn))
@@ -1475,7 +1470,7 @@ func (sf *WrapperMsgCreatePool2) ParseRelevantData() []parsingTypes.MessageRelev
 
 func (sf *WrapperMsgCreatePool) ParseRelevantData() []parsingTypes.MessageRelevantInformation {
 	// need to make a relevant data block for all Tokens sent to the pool on creation
-	var relevantData = make([]parsingTypes.MessageRelevantInformation, len(sf.CoinsSpent)+len(sf.OtherCoinsReceived))
+	relevantData := make([]parsingTypes.MessageRelevantInformation, len(sf.CoinsSpent)+len(sf.OtherCoinsReceived))
 
 	// figure out how many gams per token
 	nthGamms, remainderGamms := calcNthGams(sf.GammCoinsReceived.Amount.BigInt(), len(sf.CoinsSpent))
@@ -1520,7 +1515,7 @@ func (sf *WrapperMsgCreatePool) ParseRelevantData() []parsingTypes.MessageReleva
 }
 
 func (sf *WrapperMsgExitSwapShareAmountIn) ParseRelevantData() []parsingTypes.MessageRelevantInformation {
-	var relevantData = make([]parsingTypes.MessageRelevantInformation, 1)
+	relevantData := make([]parsingTypes.MessageRelevantInformation, 1)
 	relevantData[0] = parsingTypes.MessageRelevantInformation{
 		AmountSent:           sf.TokenIn.Amount.BigInt(),
 		DenominationSent:     sf.TokenIn.Denom,
@@ -1533,12 +1528,12 @@ func (sf *WrapperMsgExitSwapShareAmountIn) ParseRelevantData() []parsingTypes.Me
 }
 
 func (sf *WrapperMsgExitSwapShareAmountIn2) ParseRelevantData() []parsingTypes.MessageRelevantInformation {
-	var relevantData = make([]parsingTypes.MessageRelevantInformation, len(sf.TokensOut))
+	relevantData := make([]parsingTypes.MessageRelevantInformation, len(sf.TokensOut))
 
 	// figure out how many gams per token
 	nthGamms, remainderGamms := calcNthGams(sf.TokenIn.Amount.BigInt(), len(sf.TokensOut))
 
-	//Handle the pool exit
+	// Handle the pool exit
 	for i, v := range sf.TokensOut {
 		// split received tokens across entry so we receive GAMM tokens for both exchanges
 		// each swap will get 1 nth of the gams until the last one which will get the remainder
@@ -1563,7 +1558,7 @@ func (sf *WrapperMsgExitSwapShareAmountIn2) ParseRelevantData() []parsingTypes.M
 		}
 	}
 
-	//Handle the post exit swap event
+	// Handle the post exit swap event
 	for _, tokensSwapped := range sf.TokenSwaps {
 		relevantData = append(relevantData, parsingTypes.MessageRelevantInformation{
 			AmountSent:           tokensSwapped.TokenSwappedIn.Amount.BigInt(),
@@ -1579,7 +1574,7 @@ func (sf *WrapperMsgExitSwapShareAmountIn2) ParseRelevantData() []parsingTypes.M
 }
 
 func (sf *WrapperMsgExitSwapExternAmountOut) ParseRelevantData() []parsingTypes.MessageRelevantInformation {
-	var relevantData = make([]parsingTypes.MessageRelevantInformation, 1)
+	relevantData := make([]parsingTypes.MessageRelevantInformation, 1)
 	relevantData[0] = parsingTypes.MessageRelevantInformation{
 		AmountSent:           sf.TokenIn.Amount.BigInt(),
 		DenominationSent:     sf.TokenIn.Denom,
@@ -1593,7 +1588,7 @@ func (sf *WrapperMsgExitSwapExternAmountOut) ParseRelevantData() []parsingTypes.
 
 func (sf *WrapperMsgExitPool) ParseRelevantData() []parsingTypes.MessageRelevantInformation {
 	// need to make a relevant data block for all Tokens received from the pool since ExitPool can receive 1 or both tokens used in the pool
-	var relevantData = make([]parsingTypes.MessageRelevantInformation, len(sf.TokensOutOfPool))
+	relevantData := make([]parsingTypes.MessageRelevantInformation, len(sf.TokensOutOfPool))
 
 	// figure out how many gams per token
 	nthGamms, remainderGamms := calcNthGams(sf.TokenIntoPool.Amount.BigInt(), len(sf.TokensOutOfPool))

--- a/osmosis/modules/poolmanager/types.go
+++ b/osmosis/modules/poolmanager/types.go
@@ -126,7 +126,7 @@ func (sf *WrapperMsgSwapExactAmountOut) HandleMsg(msgType string, msg sdk.Msg, l
 }
 
 func (sf *WrapperMsgSwapExactAmountIn) ParseRelevantData() []parsingTypes.MessageRelevantInformation {
-	var relevantData = make([]parsingTypes.MessageRelevantInformation, 1)
+	relevantData := make([]parsingTypes.MessageRelevantInformation, 1)
 	relevantData[0] = parsingTypes.MessageRelevantInformation{
 		AmountSent:           sf.TokenIn.Amount.BigInt(),
 		DenominationSent:     sf.TokenIn.Denom,
@@ -139,7 +139,7 @@ func (sf *WrapperMsgSwapExactAmountIn) ParseRelevantData() []parsingTypes.Messag
 }
 
 func (sf *WrapperMsgSwapExactAmountOut) ParseRelevantData() []parsingTypes.MessageRelevantInformation {
-	var relevantData = make([]parsingTypes.MessageRelevantInformation, 1)
+	relevantData := make([]parsingTypes.MessageRelevantInformation, 1)
 	relevantData[0] = parsingTypes.MessageRelevantInformation{
 		AmountSent:           sf.TokenIn.Amount.BigInt(),
 		DenominationSent:     sf.TokenIn.Denom,

--- a/rest/requests.go
+++ b/rest/requests.go
@@ -58,7 +58,6 @@ func GetTxsByBlockHeight(host string, height uint64) (tx.GetTxByBlockHeightRespo
 	requestEndpoint := fmt.Sprintf(apiEndpoints["txs_by_block_height_endpoint"], height)
 
 	resp, err := http.Get(fmt.Sprintf("%s%s", host, requestEndpoint))
-
 	if err != nil {
 		return result, err
 	}
@@ -72,7 +71,6 @@ func GetTxsByBlockHeight(host string, height uint64) (tx.GetTxByBlockHeightRespo
 	}
 
 	body, err := io.ReadAll(resp.Body)
-
 	if err != nil {
 		return result, err
 	}
@@ -92,7 +90,6 @@ func GetLatestBlock(host string) (tx.GetLatestBlockResponse, error) {
 	requestEndpoint := apiEndpoints["latest_block_endpoint"]
 
 	resp, err := http.Get(fmt.Sprintf("%s%s", host, requestEndpoint))
-
 	if err != nil {
 		return result, err
 	}
@@ -106,7 +103,6 @@ func GetLatestBlock(host string) (tx.GetLatestBlockResponse, error) {
 	}
 
 	body, err := io.ReadAll(resp.Body)
-
 	if err != nil {
 		return result, err
 	}

--- a/rpc/rpc_test.go
+++ b/rpc/rpc_test.go
@@ -9,9 +9,7 @@ import (
 	"testing"
 
 	"github.com/DefiantLabs/cosmos-tax-cli/config"
-
 	"github.com/DefiantLabs/lens/client"
-	lensClient "github.com/DefiantLabs/lens/client"
 	lensQuery "github.com/DefiantLabs/lens/client/query"
 	"github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/assert"
@@ -95,32 +93,32 @@ func TestDecodeIBCTypes(t *testing.T) {
 	assert.True(t, hasIbcType)
 }
 
-func GetJunoTestClient(t *testing.T) *lensClient.ChainClient {
+func GetJunoTestClient(t *testing.T) *client.ChainClient {
 	homepath := getHomePath(t)
 	// IMPORTANT: the actual keyring-test will be searched for at the path {homepath}/keys/{ChainID}/keyring-test.
 	// You can use lens default settings to generate that directory appropriately then move it to the desired path.
 	// For example, 'lens keys restore default' will restore the key to the default keyring (e.g. /home/kyle/.lens/...)
 	// and you can move all of the necessary keys to whatever homepath you want to use. Or you can use --home flag.
-	cl, err := lensClient.NewChainClient(GetJunoConfig(homepath, true), homepath, nil, nil)
+	cl, err := client.NewChainClient(GetJunoConfig(homepath, true), homepath, nil, nil)
 	assert.Nil(t, err)
 	config.RegisterAdditionalTypes(cl)
 	return cl
 }
 
-func GetOsmosisTestClient(t *testing.T) *lensClient.ChainClient {
+func GetOsmosisTestClient(t *testing.T) *client.ChainClient {
 	homepath := getHomePath(t)
 	// IMPORTANT: the actual keyring-test will be searched for at the path {homepath}/keys/{ChainID}/keyring-test.
 	// You can use lens default settings to generate that directory appropriately then move it to the desired path.
 	// For example, 'lens keys restore default' will restore the key to the default keyring (e.g. /home/kyle/.lens/...)
 	// and you can move all of the necessary keys to whatever homepath you want to use. Or you can use --home flag.
-	cl, err := lensClient.NewChainClient(GetOsmosisConfig(homepath, true), homepath, nil, nil)
+	cl, err := client.NewChainClient(GetOsmosisConfig(homepath, true), homepath, nil, nil)
 	assert.Nil(t, err)
 	config.RegisterAdditionalTypes(cl)
 	return cl
 }
 
-func GetJunoConfig(keyHome string, debug bool) *lensClient.ChainClientConfig {
-	return &lensClient.ChainClientConfig{
+func GetJunoConfig(keyHome string, debug bool) *client.ChainClientConfig {
+	return &client.ChainClientConfig{
 		Key:            "default",
 		ChainID:        "testing",
 		RPCAddr:        "http://localhost:26657",
@@ -138,9 +136,9 @@ func GetJunoConfig(keyHome string, debug bool) *lensClient.ChainClientConfig {
 	}
 }
 
-func GetOsmosisConfig(keyHome string, debug bool) *lensClient.ChainClientConfig {
+func GetOsmosisConfig(keyHome string, debug bool) *client.ChainClientConfig {
 	log.Println(keyHome)
-	return &lensClient.ChainClientConfig{
+	return &client.ChainClientConfig{
 		Key:            "default",
 		ChainID:        "osmosis-1",
 		RPCAddr:        "https://osmosis-mainnet-archive.allthatnode.com:26657",

--- a/tasks/denoms.go
+++ b/tasks/denoms.go
@@ -84,7 +84,7 @@ func UpsertJunoDenoms(db *gorm.DB) {
 }
 
 func assetListToDenoms(assets *AssetList) []dbTypes.DenomDBWrapper {
-	var denoms []dbTypes.DenomDBWrapper = make([]dbTypes.DenomDBWrapper, len(assets.Assets))
+	denoms := make([]dbTypes.DenomDBWrapper, len(assets.Assets))
 	for i, asset := range assets.Assets {
 		denoms[i].Denom = dbTypes.Denom{Base: asset.Base, Name: asset.Name, Symbol: asset.Symbol}
 		denoms[i].DenomUnits = make([]dbTypes.DenomUnitDBWrapper, len(asset.Denoms))

--- a/tasks/denoms.go
+++ b/tasks/denoms.go
@@ -91,7 +91,6 @@ func assetListToDenoms(assets *AssetList) []dbTypes.DenomDBWrapper {
 
 		for ii, denomUnit := range asset.Denoms {
 			denoms[i].DenomUnits[ii].DenomUnit = dbTypes.DenomUnit{Exponent: uint(denomUnit.Exponent), Name: denomUnit.Denom}
-
 		}
 	}
 
@@ -109,7 +108,7 @@ func getAssetsList(assetsURL string) (*AssetList, error) {
 }
 
 func getJSON(url string, target interface{}) error {
-	var myClient = &http.Client{Timeout: 10 * time.Second}
+	myClient := &http.Client{Timeout: 10 * time.Second}
 
 	r, err := myClient.Get(url)
 	if err != nil {

--- a/tendermint/events/liquidity/types.go
+++ b/tendermint/events/liquidity/types.go
@@ -125,13 +125,13 @@ func (sf *WrapperBlockEventSwapTransacted) HandleEvent(eventType string, event a
 
 	offerAmount, ok := sdk.NewIntFromString(offerCoinAmount)
 	if !ok {
-		return fmt.Errorf("Error parsing coin amount for offerCoinAmount %s", offerCoinAmount)
+		return fmt.Errorf("error parsing coin amount for offerCoinAmount %s", offerCoinAmount)
 	}
 	sf.CoinSwappedIn = sdk.NewCoin(offerCoinDenom, offerAmount)
 
 	demandAmount, ok := sdk.NewIntFromString(demandCoinAmount)
 	if !ok {
-		return fmt.Errorf("Error parsing coin amount for demandCoinAmount %s", demandCoinAmount)
+		return fmt.Errorf("error parsing coin amount for demandCoinAmount %s", demandCoinAmount)
 	}
 	sf.CoinSwappedOut = sdk.NewCoin(demandCoinDenom, demandAmount)
 
@@ -141,7 +141,7 @@ func (sf *WrapperBlockEventSwapTransacted) HandleEvent(eventType string, event a
 	}
 	offerFeeAmount, ok := sdk.NewIntFromString(offerCoinFeeAmount)
 	if !ok {
-		return fmt.Errorf("Error parsing coin amount for offerCoinFeeAmount %s", offerCoinFeeAmount)
+		return fmt.Errorf("error parsing coin amount for offerCoinFeeAmount %s", offerCoinFeeAmount)
 	}
 	firstFee := sdk.NewCoin(offerCoinDenom, offerFeeAmount)
 
@@ -151,7 +151,7 @@ func (sf *WrapperBlockEventSwapTransacted) HandleEvent(eventType string, event a
 	}
 	demandFeeAmount, ok := sdk.NewIntFromString(demandCoinFeeAmount)
 	if !ok {
-		return fmt.Errorf("Error parsing coin amount for demandCoinFeeAmount %s", demandCoinFeeAmount)
+		return fmt.Errorf("error parsing coin amount for demandCoinFeeAmount %s", demandCoinFeeAmount)
 	}
 	secondFee := sdk.NewCoin(demandCoinDenom, demandFeeAmount)
 

--- a/tendermint/events/liquidity/types.go
+++ b/tendermint/events/liquidity/types.go
@@ -301,7 +301,6 @@ func (sf *WrapperBlockEventSwapTransacted) String() string {
 }
 
 func (sf *WrapperBlockWithdrawFromPool) String() string {
-
 	feesPaidString := "No fees were paid"
 	if len(sf.WithdrawFees) != 0 {
 		feesPaidString = fmt.Sprintf("Fees paid were %s", sf.WithdrawFees)

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -68,7 +68,6 @@ func ensureTestAddress(db *gorm.DB) dbUtils.Address {
 //   - Returns various values used throughout the application
 func dbSetup(addressRegex string, addressPrefix string) (*gorm.DB, error) {
 	config, err := configUtils.GetConfig("../config.toml")
-
 	if err != nil {
 		fmt.Println("Error opening configuration file", err)
 		return nil, err

--- a/test/indexer_test.go
+++ b/test/indexer_test.go
@@ -35,7 +35,7 @@ func TestOsmosisCsvForAddress(t *testing.T) {
 		t.Fatal("CSV length should never be 0, there are always headers!")
 	}
 
-	err = os.WriteFile("accointing.csv", buffer.Bytes(), 0600)
+	err = os.WriteFile("accointing.csv", buffer.Bytes(), 0o600)
 	if err != nil {
 		t.Fatal("Failed to write CSV to disk")
 	}
@@ -63,7 +63,7 @@ func TestCsvForAddress(t *testing.T) {
 		t.Fatal("CSV length should never be 0, there are always headers!")
 	}
 
-	err = os.WriteFile("accointing.csv", buffer.Bytes(), 0600)
+	err = os.WriteFile("accointing.csv", buffer.Bytes(), 0o600)
 	if err != nil {
 		t.Fatal("Failed to write CSV to disk")
 	}


### PR DESCRIPTION
Fix the rest of the stylecheck related linter errors.

- ST1022, ensuring Go comments being with the name of the function/variable they are commenting on.
- ST1023, should omit type when it can be inferred.

Please merge https://github.com/DefiantLabs/cosmos-tax-cli/pull/400, https://github.com/DefiantLabs/cosmos-tax-cli/pull/401 and then #402 first.

Part of the work to address #331 