### PR TITLE
Remove Fatal errors from CSV functions run by the API

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -244,7 +244,7 @@ func GetTaxableEventsCSV(c *gin.Context) {
 	buffer, err := csv.ToCsv(accountRows, headers)
 	if err != nil {
 		config.Log.Error("Error generating CSV", err)
-		c.AbortWithError(500, errors.New("error getting rows for address"))
+		c.AbortWithError(500, errors.New("error getting rows for address")) // nolint:staticcheck,errcheck
 		return
 	}
 

--- a/client/client.go
+++ b/client/client.go
@@ -241,7 +241,13 @@ func GetTaxableEventsCSV(c *gin.Context) {
 		return
 	}
 
-	buffer := csv.ToCsv(accountRows, headers)
+	buffer, err := csv.ToCsv(accountRows, headers)
+	if err != nil {
+		config.Log.Error("Error generating CSV", err)
+		c.AbortWithError(500, errors.New("error getting rows for address"))
+		return
+	}
+
 	c.Data(200, "text/csv", buffer.Bytes())
 }
 

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -76,7 +76,10 @@ var queryCmd = &cobra.Command{
 			config.Log.Fatal("Error calling parser for address", err)
 		}
 
-		buffer := csv.ToCsv(csvRows, headers)
+		buffer, err := csv.ToCsv(csvRows, headers)
+		if err != nil {
+			config.Log.Fatal("Error generating CSV", err)
+		}
 		fmt.Println(buffer.String())
 	},
 }

--- a/csv/accounting_test.go
+++ b/csv/accounting_test.go
@@ -44,7 +44,8 @@ func TestAccointingIbcMsgTransferSelf(t *testing.T) {
 	assert.Nil(t, err, "should not get error from parsing these transactions")
 
 	// validate output
-	rows := parser.GetRows(sourceAddress.Address, nil, nil)
+	rows, err := parser.GetRows(sourceAddress.Address, nil, nil)
+	assert.Nil(t, err, "should not get error from getting rows")
 	assert.Equalf(t, len(transferTxs), len(rows), "you should have one row for each transfer transaction ")
 	assert.Equal(t, transferTxs[0].Message.MessageType.MessageType, ibc.MsgTransfer, "message type should be an IBC transfer")
 
@@ -88,7 +89,8 @@ func TestAccointingIbcMsgTransferExternal(t *testing.T) {
 	assert.Nil(t, err, "should not get error from parsing these transactions")
 
 	// validate output
-	rows := parser.GetRows(sourceAddress.Address, nil, nil)
+	rows, err := parser.GetRows(sourceAddress.Address, nil, nil)
+	assert.Nil(t, err, "should not get error from getting rows")
 	assert.Equalf(t, len(transferTxs), len(rows), "you should have one row for each transfer transaction ")
 	assert.Equal(t, transferTxs[0].Message.MessageType.MessageType, ibc.MsgTransfer, "message type should be an IBC transfer")
 
@@ -119,7 +121,8 @@ func TestAccointingOsmoLPParsing(t *testing.T) {
 	assert.Nil(t, err, "should not get error from parsing these transactions")
 
 	// validate output
-	rows := parser.GetRows(targetAddress.Address, nil, nil)
+	rows, err := parser.GetRows(targetAddress.Address, nil, nil)
+	assert.Nil(t, err, "should not get error from getting rows")
 	assert.Equalf(t, len(transferTxs), len(rows), "you should have one row for each transfer transaction ")
 
 	// all transactions should be orders classified as liquidity_pool
@@ -154,7 +157,8 @@ func TestAccointingOsmoRewardParsing(t *testing.T) {
 	assert.Nil(t, err, "should not get error from parsing these transactions")
 
 	// validate output
-	rows := parser.GetRows(targetAddress.Address, nil, nil)
+	rows, err := parser.GetRows(targetAddress.Address, nil, nil)
+	assert.Nil(t, err, "should not get error from getting rows")
 	assert.Equalf(t, len(taxableEvents), len(rows), "you should have one row for each transfer transaction ")
 
 	// all transactions should be orders classified as liquidity_pool

--- a/csv/koinly_test.go
+++ b/csv/koinly_test.go
@@ -29,7 +29,8 @@ func TestKoinlyOsmoLPParsing(t *testing.T) {
 	assert.Nil(t, err, "should not get error from parsing these transactions")
 
 	// validate output
-	rows := parser.GetRows(targetAddress.Address, nil, nil)
+	rows, err := parser.GetRows(targetAddress.Address, nil, nil)
+	assert.Nil(t, err, "should not get error from getting rows")
 	assert.Equalf(t, len(transferTxs), len(rows), "you should have one row for each transfer transaction ")
 
 	// all transactions should be orders classified as liquidity_pool
@@ -67,7 +68,8 @@ func TestKoinlyOsmoRewardParsing(t *testing.T) {
 	assert.Nil(t, err, "should not get error from parsing these transactions")
 
 	// validate output
-	rows := parser.GetRows(targetAddress.Address, nil, nil)
+	rows, err := parser.GetRows(targetAddress.Address, nil, nil)
+	assert.Nil(t, err, "should not get error from getting rows")
 	assert.Equalf(t, len(taxableEvents), len(rows), "you should have one row for each transfer transaction ")
 
 	// all transactions should be orders classified as liquidity_pool

--- a/csv/parser.go
+++ b/csv/parser.go
@@ -81,7 +81,11 @@ func ParseForAddress(addresses []string, startDate, endDate *time.Time, pgSQL *g
 		}
 
 		// Get rows once right at the end, also filter them by date
-		rows := parser.GetRows(address, startDate, endDate)
+		rows, err := parser.GetRows(address, startDate, endDate)
+
+		if err != nil {
+			return nil, nil, err
+		}
 
 		csvRows = append(csvRows, rows...)
 		headers = parser.GetHeaders()

--- a/csv/parser.go
+++ b/csv/parser.go
@@ -82,7 +82,6 @@ func ParseForAddress(addresses []string, startDate, endDate *time.Time, pgSQL *g
 
 		// Get rows once right at the end, also filter them by date
 		rows, err := parser.GetRows(address, startDate, endDate)
-
 		if err != nil {
 			return nil, nil, err
 		}

--- a/csv/parsers/accointing/accointing.go
+++ b/csv/parsers/accointing/accointing.go
@@ -69,7 +69,11 @@ func (p *Parser) ProcessTaxableEvent(taxableEvents []db.TaxableEvent) error {
 	// Parse all the potentially taxable events
 	for _, event := range taxableEvents {
 		// generate the rows for the CSV.
-		p.Rows = append(p.Rows, ParseEvent(event)...)
+		rows, err := ParseEvent(event)
+		if err != nil {
+			return err
+		}
+		p.Rows = append(p.Rows, rows...)
 	}
 
 	return nil
@@ -196,16 +200,17 @@ func HandleFees(address string, events []db.TaxableTransaction) (rows []Row, err
 }
 
 // ParseEvent: Parse the potentially taxable event
-func ParseEvent(event db.TaxableEvent) (rows []Row) {
+func ParseEvent(event db.TaxableEvent) (rows []Row, err error) {
 	if event.Source == db.OsmosisRewardDistribution {
 		row, err := ParseOsmosisReward(event)
 		if err != nil {
-			config.Log.Fatal("error parsing row. Should be impossible to reach this condition, ideally (once all bugs worked out)", err)
+			config.Log.Error("error parsing row. Should be impossible to reach this condition, ideally (once all bugs worked out)", err)
+			return nil, err
 		}
 		rows = append(rows, row)
 	}
 
-	return rows
+	return rows, nil
 }
 
 // ParseTx: Parse the potentially taxable TX and Messages

--- a/csv/parsers/accointing/accointing.go
+++ b/csv/parsers/accointing/accointing.go
@@ -79,7 +79,7 @@ func (p *Parser) InitializeParsingGroups() {
 	p.ParsingGroups = append(p.ParsingGroups, parsers.GetOsmosisTxParsingGroups()...)
 }
 
-func (p *Parser) GetRows(address string, startDate, endDate *time.Time) []parsers.CsvRow {
+func (p *Parser) GetRows(address string, startDate, endDate *time.Time) ([]parsers.CsvRow, error) {
 	// Combine all normal rows and parser group rows into 1
 	accointingRows := p.Rows // contains TX rows and fees as well as taxable events
 	for _, v := range p.ParsingGroups {
@@ -110,7 +110,8 @@ func (p *Parser) GetRows(address string, startDate, endDate *time.Time) []parser
 		if startDate != nil && firstToKeep == nil {
 			rowDate, err := time.Parse(TimeLayout, accointingRows[i].Date)
 			if err != nil {
-				config.Log.Fatal("Error parsing row date.", err)
+				config.Log.Error("Error parsing row date.", err)
+				return nil, err
 			}
 			if rowDate.Before(*startDate) {
 				continue
@@ -120,7 +121,8 @@ func (p *Parser) GetRows(address string, startDate, endDate *time.Time) []parser
 		} else if endDate != nil && lastToKeep == nil {
 			rowDate, err := time.Parse(TimeLayout, accointingRows[i].Date)
 			if err != nil {
-				config.Log.Fatal("Error parsing row date.", err)
+				config.Log.Error("Error parsing row date.", err)
+				return nil, err
 			}
 			if rowDate.Before(*endDate) {
 				continue
@@ -146,7 +148,7 @@ func (p *Parser) GetRows(address string, startDate, endDate *time.Time) []parser
 		csvRows[i] = v
 	}
 
-	return csvRows
+	return csvRows, nil
 }
 
 func (p Parser) GetHeaders() []string {

--- a/csv/parsers/accointing/accointing.go
+++ b/csv/parsers/accointing/accointing.go
@@ -221,7 +221,7 @@ func ParseEvent(event db.TaxableEvent) (rows []Row, err error) {
 func ParseTx(address string, events []db.TaxableTransaction) (rows []parsers.CsvRow, err error) {
 	for _, event := range events {
 		var newRow Row
-		var err error = nil
+		var err error
 		switch event.Message.MessageType.MessageType {
 		case bank.MsgSendV0:
 			newRow, err = ParseMsgSend(address, event)

--- a/csv/parsers/accointing/accointing.go
+++ b/csv/parsers/accointing/accointing.go
@@ -213,137 +213,145 @@ func ParseEvent(event db.TaxableEvent) (rows []Row) {
 // Whether or not a message must be parsed as a group depends on whether the taxable implications are clear without further context.
 func ParseTx(address string, events []db.TaxableTransaction) (rows []parsers.CsvRow, err error) {
 	for _, event := range events {
+		var newRow Row
+		var err error = nil
 		switch event.Message.MessageType.MessageType {
 		case bank.MsgSendV0:
-			rows = append(rows, ParseMsgSend(address, event))
+			newRow, err = ParseMsgSend(address, event)
 		case bank.MsgSend:
-			rows = append(rows, ParseMsgSend(address, event))
+			newRow, err = ParseMsgSend(address, event)
 		case bank.MsgMultiSendV0:
-			rows = append(rows, ParseMsgMultiSend(address, event))
+			newRow, err = ParseMsgMultiSend(address, event)
 		case bank.MsgMultiSend:
-			rows = append(rows, ParseMsgMultiSend(address, event))
+			newRow, err = ParseMsgMultiSend(address, event)
 		case distribution.MsgFundCommunityPool:
-			rows = append(rows, ParseMsgFundCommunityPool(address, event))
+			newRow, err = ParseMsgFundCommunityPool(address, event)
 		case distribution.MsgWithdrawValidatorCommission:
-			rows = append(rows, ParseMsgWithdrawValidatorCommission(address, event))
+			newRow, err = ParseMsgWithdrawValidatorCommission(address, event)
 		case distribution.MsgWithdrawRewards:
-			rows = append(rows, ParseMsgWithdrawDelegatorReward(address, event))
+			newRow, err = ParseMsgWithdrawDelegatorReward(address, event)
 		case distribution.MsgWithdrawDelegatorReward:
-			rows = append(rows, ParseMsgWithdrawDelegatorReward(address, event))
+			newRow, err = ParseMsgWithdrawDelegatorReward(address, event)
 		case staking.MsgDelegate:
-			rows = append(rows, ParseMsgWithdrawDelegatorReward(address, event))
+			newRow, err = ParseMsgWithdrawDelegatorReward(address, event)
 		case staking.MsgUndelegate:
-			rows = append(rows, ParseMsgWithdrawDelegatorReward(address, event))
+			newRow, err = ParseMsgWithdrawDelegatorReward(address, event)
 		case staking.MsgBeginRedelegate:
-			rows = append(rows, ParseMsgWithdrawDelegatorReward(address, event))
+			newRow, err = ParseMsgWithdrawDelegatorReward(address, event)
 		case gamm.MsgSwapExactAmountIn:
-			rows = append(rows, ParseMsgSwapExactAmountIn(event))
+			newRow, err = ParseMsgSwapExactAmountIn(event)
 		case gamm.MsgSwapExactAmountOut:
-			rows = append(rows, ParseMsgSwapExactAmountOut(event))
+			newRow, err = ParseMsgSwapExactAmountOut(event)
 		case gov.MsgSubmitProposal:
-			rows = append(rows, ParseMsgSubmitProposal(address, event))
+			newRow, err = ParseMsgSubmitProposal(address, event)
 		case gov.MsgDeposit:
-			rows = append(rows, ParseMsgDeposit(address, event))
+			newRow, err = ParseMsgDeposit(address, event)
 		case ibc.MsgTransfer:
-			rows = append(rows, ParseMsgTransfer(address, event))
+			newRow, err = ParseMsgTransfer(address, event)
 		default:
 			return nil, fmt.Errorf("no parser for message type '%v'", event.Message.MessageType.MessageType)
 		}
+
+		if err != nil {
+			return nil, fmt.Errorf("error parsing message type '%v'", event.Message.MessageType.MessageType)
+		}
+
+		rows = append(rows, newRow)
 	}
 	return rows, nil
 }
 
 // ParseMsgValidatorWithdraw:
 // This transaction is always a withdrawal.
-func ParseMsgWithdrawValidatorCommission(address string, event db.TaxableTransaction) Row {
+func ParseMsgWithdrawValidatorCommission(address string, event db.TaxableTransaction) (Row, error) {
 	row := &Row{}
 	err := row.ParseBasic(address, event)
 	if err != nil {
-		config.Log.Fatal("Error with ParseMsgWithdrawValidatorCommission.", err)
+		config.Log.Error("Error with ParseMsgWithdrawValidatorCommission.", err)
 	}
 	row.Classification = Staked
-	return *row
+	return *row, err
 }
 
 // ParseMsgValidatorWithdraw:
 // This transaction is always a withdrawal.
-func ParseMsgWithdrawDelegatorReward(address string, event db.TaxableTransaction) Row {
+func ParseMsgWithdrawDelegatorReward(address string, event db.TaxableTransaction) (Row, error) {
 	row := &Row{}
 	err := row.ParseBasic(address, event)
 	if err != nil {
-		config.Log.Fatal("Error with ParseMsgWithdrawDelegatorReward.", err)
+		config.Log.Error("Error with ParseMsgWithdrawDelegatorReward.", err)
 	}
 	row.Classification = Staked
-	return *row
+	return *row, err
 }
 
 // ParseMsgSend:
 // If the address we searched is the receiver, then this transaction is a deposit.
 // If the address we searched is the sender, then this transaction is a withdrawal.
-func ParseMsgSend(address string, event db.TaxableTransaction) Row {
+func ParseMsgSend(address string, event db.TaxableTransaction) (Row, error) {
 	row := &Row{}
 	err := row.ParseBasic(address, event)
 	if err != nil {
-		config.Log.Fatal("Error with ParseMsgSend.", err)
+		config.Log.Error("Error with ParseMsgSend.", err)
 	}
-	return *row
+	return *row, err
 }
 
-func ParseMsgMultiSend(address string, event db.TaxableTransaction) Row {
+func ParseMsgMultiSend(address string, event db.TaxableTransaction) (Row, error) {
 	row := &Row{}
 	err := row.ParseBasic(address, event)
 	if err != nil {
-		config.Log.Fatal("Error with ParseMsgMultiSend.", err)
+		config.Log.Error("Error with ParseMsgMultiSend.", err)
 	}
-	return *row
+	return *row, err
 }
 
-func ParseMsgFundCommunityPool(address string, event db.TaxableTransaction) Row {
+func ParseMsgFundCommunityPool(address string, event db.TaxableTransaction) (Row, error) {
 	row := &Row{}
 	err := row.ParseBasic(address, event)
 	if err != nil {
-		config.Log.Fatal("Error with ParseMsgFundCommunityPool.", err)
+		config.Log.Error("Error with ParseMsgFundCommunityPool.", err)
 	}
-	return *row
+	return *row, err
 }
 
-func ParseMsgSubmitProposal(address string, event db.TaxableTransaction) Row {
+func ParseMsgSubmitProposal(address string, event db.TaxableTransaction) (Row, error) {
 	row := &Row{}
 	err := row.ParseBasic(address, event)
 	if err != nil {
-		config.Log.Fatal("Error with ParseMsgSubmitProposal.", err)
+		config.Log.Error("Error with ParseMsgSubmitProposal.", err)
 	}
-	return *row
+	return *row, err
 }
 
-func ParseMsgDeposit(address string, event db.TaxableTransaction) Row {
+func ParseMsgDeposit(address string, event db.TaxableTransaction) (Row, error) {
 	row := &Row{}
 	err := row.ParseBasic(address, event)
 	if err != nil {
-		config.Log.Fatal("Error with ParseMsgDeposit.", err)
+		config.Log.Error("Error with ParseMsgDeposit.", err)
 	}
-	return *row
+	return *row, err
 }
 
-func ParseMsgSwapExactAmountIn(event db.TaxableTransaction) Row {
+func ParseMsgSwapExactAmountIn(event db.TaxableTransaction) (Row, error) {
 	row := &Row{}
 	err := row.ParseSwap(event)
 	if err != nil {
-		config.Log.Fatal("Error with ParseMsgSwapExactAmountIn.", err)
+		config.Log.Error("Error with ParseMsgSwapExactAmountIn.", err)
 	}
-	return *row
+	return *row, err
 }
 
-func ParseMsgSwapExactAmountOut(event db.TaxableTransaction) Row {
+func ParseMsgSwapExactAmountOut(event db.TaxableTransaction) (Row, error) {
 	row := &Row{}
 	err := row.ParseSwap(event)
 	if err != nil {
-		config.Log.Fatal("Error with ParseMsgSwapExactAmountOut.", err)
+		config.Log.Error("Error with ParseMsgSwapExactAmountOut.", err)
 	}
-	return *row
+	return *row, err
 }
 
-func ParseMsgTransfer(address string, event db.TaxableTransaction) Row {
+func ParseMsgTransfer(address string, event db.TaxableTransaction) (Row, error) {
 	row := &Row{}
 	err := row.ParseBasic(address, event)
 	selfTransfer := false
@@ -360,16 +368,16 @@ func ParseMsgTransfer(address string, event db.TaxableTransaction) Row {
 	}
 
 	if err != nil {
-		config.Log.Fatal("Error with ParseMsgTransfer.", err)
+		config.Log.Error("Error with ParseMsgTransfer.", err)
 	}
-	return *row
+	return *row, err
 }
 
 func ParseOsmosisReward(event db.TaxableEvent) (Row, error) {
 	row := &Row{}
 	err := row.EventParseBasic(event)
 	if err != nil {
-		config.Log.Fatal("Error with ParseOsmosisReward.", err)
+		config.Log.Error("Error with ParseOsmosisReward.", err)
 	}
 	return *row, err
 }

--- a/csv/parsers/cointracker/cointracker.go
+++ b/csv/parsers/cointracker/cointracker.go
@@ -206,143 +206,151 @@ func ParseEvent(event db.TaxableEvent) (rows []Row) {
 // Use TX Parsing Groups to parse txes as a group
 func ParseTx(address string, events []db.TaxableTransaction) (rows []parsers.CsvRow, err error) {
 	for _, event := range events {
+		var newRow Row
+		var err error = nil
 		switch event.Message.MessageType.MessageType {
 		case bank.MsgSendV0:
-			rows = append(rows, ParseMsgSend(address, event))
+			newRow, err = ParseMsgSend(address, event)
 		case bank.MsgSend:
-			rows = append(rows, ParseMsgSend(address, event))
+			newRow, err = ParseMsgSend(address, event)
 		case bank.MsgMultiSendV0:
-			rows = append(rows, ParseMsgMultiSend(address, event))
+			newRow, err = ParseMsgMultiSend(address, event)
 		case bank.MsgMultiSend:
-			rows = append(rows, ParseMsgMultiSend(address, event))
+			newRow, err = ParseMsgMultiSend(address, event)
 		case distribution.MsgFundCommunityPool:
-			rows = append(rows, ParseMsgFundCommunityPool(address, event))
+			newRow, err = ParseMsgFundCommunityPool(address, event)
 		case distribution.MsgWithdrawValidatorCommission:
-			rows = append(rows, ParseMsgWithdrawValidatorCommission(address, event))
+			newRow, err = ParseMsgWithdrawValidatorCommission(address, event)
 		case distribution.MsgWithdrawRewards:
-			rows = append(rows, ParseMsgWithdrawDelegatorReward(address, event))
+			newRow, err = ParseMsgWithdrawDelegatorReward(address, event)
 		case distribution.MsgWithdrawDelegatorReward:
-			rows = append(rows, ParseMsgWithdrawDelegatorReward(address, event))
+			newRow, err = ParseMsgWithdrawDelegatorReward(address, event)
 		case staking.MsgDelegate:
-			rows = append(rows, ParseMsgWithdrawDelegatorReward(address, event))
+			newRow, err = ParseMsgWithdrawDelegatorReward(address, event)
 		case staking.MsgUndelegate:
-			rows = append(rows, ParseMsgWithdrawDelegatorReward(address, event))
+			newRow, err = ParseMsgWithdrawDelegatorReward(address, event)
 		case staking.MsgBeginRedelegate:
-			rows = append(rows, ParseMsgWithdrawDelegatorReward(address, event))
+			newRow, err = ParseMsgWithdrawDelegatorReward(address, event)
 		case gov.MsgSubmitProposal:
-			rows = append(rows, ParseMsgSubmitProposal(address, event))
+			newRow, err = ParseMsgSubmitProposal(address, event)
 		case gov.MsgDeposit:
-			rows = append(rows, ParseMsgDeposit(address, event))
+			newRow, err = ParseMsgDeposit(address, event)
 		case gamm.MsgSwapExactAmountIn:
-			rows = append(rows, ParseMsgSwapExactAmountIn(event))
+			newRow, err = ParseMsgSwapExactAmountIn(event)
 		case gamm.MsgSwapExactAmountOut:
-			rows = append(rows, ParseMsgSwapExactAmountOut(event))
+			newRow, err = ParseMsgSwapExactAmountOut(event)
 		case ibc.MsgTransfer:
-			rows = append(rows, ParseMsgTransfer(address, event))
+			newRow, err = ParseMsgTransfer(address, event)
 		default:
 			return nil, fmt.Errorf("no parser for message type '%v'", event.Message.MessageType.MessageType)
 		}
+
+		if err != nil {
+			return nil, fmt.Errorf("error parsing message type '%v'", event.Message.MessageType.MessageType)
+		}
+
+		rows = append(rows, newRow)
 	}
 	return rows, nil
 }
 
 // ParseMsgValidatorWithdraw:
 // This transaction is always a withdrawal.
-func ParseMsgWithdrawValidatorCommission(address string, event db.TaxableTransaction) Row {
+func ParseMsgWithdrawValidatorCommission(address string, event db.TaxableTransaction) (Row, error) {
 	row := &Row{}
 	err := row.ParseBasic(address, event)
 	if err != nil {
-		config.Log.Fatal("Error with ParseMsgWithdrawValidatorCommission.", err)
+		config.Log.Error("Error with ParseMsgWithdrawValidatorCommission.", err)
 	}
 	// row.Label = Unstake
-	return *row
+	return *row, err
 }
 
 // ParseMsgValidatorWithdraw:
 // This transaction is always a withdrawal.
-func ParseMsgWithdrawDelegatorReward(address string, event db.TaxableTransaction) Row {
+func ParseMsgWithdrawDelegatorReward(address string, event db.TaxableTransaction) (Row, error) {
 	row := &Row{}
 	err := row.ParseBasic(address, event)
 	if err != nil {
-		config.Log.Fatal("Error with ParseMsgWithdrawDelegatorReward.", err)
+		config.Log.Error("Error with ParseMsgWithdrawDelegatorReward.", err)
 	}
 	// row.Label = Unstake
-	return *row
+	return *row, err
 }
 
 // ParseMsgSend:
 // If the address we searched is the receiver, then this transaction is a deposit.
 // If the address we searched is the sender, then this transaction is a withdrawal.
-func ParseMsgSend(address string, event db.TaxableTransaction) Row {
+func ParseMsgSend(address string, event db.TaxableTransaction) (Row, error) {
 	row := &Row{}
 	err := row.ParseBasic(address, event)
 	if err != nil {
-		config.Log.Fatal("Error with ParseMsgSend.", err)
+		config.Log.Error("Error with ParseMsgSend.", err)
 	}
-	return *row
+	return *row, err
 }
 
-func ParseMsgMultiSend(address string, event db.TaxableTransaction) Row {
+func ParseMsgMultiSend(address string, event db.TaxableTransaction) (Row, error) {
 	row := &Row{}
 	err := row.ParseBasic(address, event)
 	if err != nil {
-		config.Log.Fatal("Error with ParseMsgMultiSend.", err)
+		config.Log.Error("Error with ParseMsgMultiSend.", err)
 	}
-	return *row
+	return *row, err
 }
 
-func ParseMsgFundCommunityPool(address string, event db.TaxableTransaction) Row {
+func ParseMsgFundCommunityPool(address string, event db.TaxableTransaction) (Row, error) {
 	row := &Row{}
 	err := row.ParseBasic(address, event)
 	if err != nil {
-		config.Log.Fatal("Error with ParseMsgFundCommunityPool.", err)
+		config.Log.Error("Error with ParseMsgFundCommunityPool.", err)
 	}
-	return *row
+	return *row, err
 }
 
-func ParseMsgSwapExactAmountIn(event db.TaxableTransaction) Row {
+func ParseMsgSwapExactAmountIn(event db.TaxableTransaction) (Row, error) {
 	row := &Row{}
 	err := row.ParseSwap(event)
 	if err != nil {
-		config.Log.Fatal("Error with ParseMsgSwapExactAmountIn.", err)
+		config.Log.Error("Error with ParseMsgSwapExactAmountIn.", err)
 	}
-	return *row
+	return *row, err
 }
 
-func ParseMsgSwapExactAmountOut(event db.TaxableTransaction) Row {
+func ParseMsgSwapExactAmountOut(event db.TaxableTransaction) (Row, error) {
 	row := &Row{}
 	err := row.ParseSwap(event)
 	if err != nil {
-		config.Log.Fatal("Error with ParseMsgSwapExactAmountOut.", err)
+		config.Log.Error("Error with ParseMsgSwapExactAmountOut.", err)
 	}
-	return *row
+	return *row, err
 }
 
-func ParseMsgTransfer(address string, event db.TaxableTransaction) Row {
+func ParseMsgTransfer(address string, event db.TaxableTransaction) (Row, error) {
 	row := &Row{}
 	err := row.ParseBasic(address, event)
 	if err != nil {
-		config.Log.Fatal("Error with ParseMsgTransfer.", err)
+		config.Log.Error("Error with ParseMsgTransfer.", err)
 	}
-	return *row
+	return *row, err
 }
 
-func ParseMsgSubmitProposal(address string, event db.TaxableTransaction) Row {
+func ParseMsgSubmitProposal(address string, event db.TaxableTransaction) (Row, error) {
 	row := &Row{}
 	err := row.ParseBasic(address, event)
 	if err != nil {
-		config.Log.Fatal("Error with ParseMsgSubmitProposal.", err)
+		config.Log.Error("Error with ParseMsgSubmitProposal.", err)
 	}
-	return *row
+	return *row, err
 }
 
-func ParseMsgDeposit(address string, event db.TaxableTransaction) Row {
+func ParseMsgDeposit(address string, event db.TaxableTransaction) (Row, error) {
 	row := &Row{}
 	err := row.ParseBasic(address, event)
 	if err != nil {
-		config.Log.Fatal("Error with ParseMsgDeposit.", err)
+		config.Log.Error("Error with ParseMsgDeposit.", err)
 	}
-	return *row
+	return *row, err
 }
 
 func ParseOsmosisReward(event db.TaxableEvent) (Row, error) {

--- a/csv/parsers/cointracker/cointracker.go
+++ b/csv/parsers/cointracker/cointracker.go
@@ -68,7 +68,11 @@ func (p *Parser) ProcessTaxableEvent(taxableEvents []db.TaxableEvent) error {
 	// Parse all the potentially taxable events
 	for _, event := range taxableEvents {
 		// generate the rows for the CSV.
-		p.Rows = append(p.Rows, ParseEvent(event)...)
+		rows, err := ParseEvent(event)
+		if err != nil {
+			return err
+		}
+		p.Rows = append(p.Rows, rows...)
 	}
 
 	return nil
@@ -191,16 +195,17 @@ func HandleFees(address string, events []db.TaxableTransaction) (rows []Row, err
 }
 
 // ParseEvent: Parse the potentially taxable event
-func ParseEvent(event db.TaxableEvent) (rows []Row) {
+func ParseEvent(event db.TaxableEvent) (rows []Row, err error) {
 	if event.Source == db.OsmosisRewardDistribution {
 		row, err := ParseOsmosisReward(event)
 		if err != nil {
-			config.Log.Fatal("error parsing row. Should be impossible to reach this condition, ideally (once all bugs worked out)", err)
+			config.Log.Error("error parsing row. Should be impossible to reach this condition, ideally (once all bugs worked out)", err)
+			return nil, err
 		}
 		rows = append(rows, row)
 	}
 
-	return rows
+	return rows, err
 }
 
 // ParseTx: Parse the potentially taxable TX and Messages
@@ -359,7 +364,7 @@ func ParseOsmosisReward(event db.TaxableEvent) (Row, error) {
 	row := &Row{}
 	err := row.EventParseBasic(event)
 	if err != nil {
-		config.Log.Fatal("Error with ParseOsmosisReward.", err)
+		config.Log.Error("Error with ParseOsmosisReward.", err)
 	}
 	return *row, err
 }

--- a/csv/parsers/cointracker/cointracker.go
+++ b/csv/parsers/cointracker/cointracker.go
@@ -78,7 +78,7 @@ func (p *Parser) InitializeParsingGroups() {
 	p.ParsingGroups = append(p.ParsingGroups, parsers.GetOsmosisTxParsingGroups()...)
 }
 
-func (p *Parser) GetRows(address string, startDate, endDate *time.Time) []parsers.CsvRow {
+func (p *Parser) GetRows(address string, startDate, endDate *time.Time) ([]parsers.CsvRow, error) {
 	// Combine all normal rows and parser group rows into 1
 	cointrackerRows := p.Rows // contains TX rows and fees as well as taxable events
 	for _, v := range p.ParsingGroups {
@@ -109,7 +109,8 @@ func (p *Parser) GetRows(address string, startDate, endDate *time.Time) []parser
 		if startDate != nil && firstToKeep == nil {
 			rowDate, err := time.Parse(TimeLayout, cointrackerRows[i].Date)
 			if err != nil {
-				config.Log.Fatal("Error parsing row date.", err)
+				config.Log.Error("Error parsing row date.", err)
+				return nil, err
 			}
 			if rowDate.Before(*startDate) {
 				continue
@@ -119,7 +120,8 @@ func (p *Parser) GetRows(address string, startDate, endDate *time.Time) []parser
 		} else if endDate != nil && lastToKeep == nil {
 			rowDate, err := time.Parse(TimeLayout, cointrackerRows[i].Date)
 			if err != nil {
-				config.Log.Fatal("Error parsing row date.", err)
+				config.Log.Error("Error parsing row date.", err)
+				return nil, err
 			}
 			if rowDate.Before(*endDate) {
 				continue
@@ -144,7 +146,7 @@ func (p *Parser) GetRows(address string, startDate, endDate *time.Time) []parser
 		csvRows[i] = v
 	}
 
-	return csvRows
+	return csvRows, nil
 }
 
 func (p Parser) GetHeaders() []string {

--- a/csv/parsers/cointracker/cointracker.go
+++ b/csv/parsers/cointracker/cointracker.go
@@ -214,7 +214,7 @@ func ParseEvent(event db.TaxableEvent) (rows []Row, err error) {
 func ParseTx(address string, events []db.TaxableTransaction) (rows []parsers.CsvRow, err error) {
 	for _, event := range events {
 		var newRow Row
-		var err error = nil
+		var err error
 		switch event.Message.MessageType.MessageType {
 		case bank.MsgSendV0:
 			newRow, err = ParseMsgSend(address, event)

--- a/csv/parsers/cryptotaxcalculator/cryptotaxcalculator.go
+++ b/csv/parsers/cryptotaxcalculator/cryptotaxcalculator.go
@@ -150,42 +150,50 @@ func ParseEvent(event db.TaxableEvent) (rows []Row) {
 
 func ParseTx(address string, events []db.TaxableTransaction) (rows []parsers.CsvRow, err error) {
 	for _, event := range events {
+		var newRow Row
+		var err error = nil
 		switch event.Message.MessageType.MessageType {
 		case bank.MsgSendV0:
-			rows = append(rows, ParseMsgSend(address, event))
+			newRow, err = ParseMsgSend(address, event)
 		case bank.MsgSend:
-			rows = append(rows, ParseMsgSend(address, event))
+			newRow, err = ParseMsgSend(address, event)
 		case bank.MsgMultiSendV0:
-			rows = append(rows, ParseMsgMultiSend(address, event))
+			newRow, err = ParseMsgMultiSend(address, event)
 		case bank.MsgMultiSend:
-			rows = append(rows, ParseMsgMultiSend(address, event))
+			newRow, err = ParseMsgMultiSend(address, event)
 		case distribution.MsgFundCommunityPool:
-			rows = append(rows, ParseMsgFundCommunityPool(address, event))
+			newRow, err = ParseMsgFundCommunityPool(address, event)
 		case distribution.MsgWithdrawValidatorCommission:
-			rows = append(rows, ParseMsgWithdrawValidatorCommission(address, event))
+			newRow, err = ParseMsgWithdrawValidatorCommission(address, event)
 		case distribution.MsgWithdrawRewards:
-			rows = append(rows, ParseMsgWithdrawDelegatorReward(address, event))
+			newRow, err = ParseMsgWithdrawDelegatorReward(address, event)
 		case distribution.MsgWithdrawDelegatorReward:
-			rows = append(rows, ParseMsgWithdrawDelegatorReward(address, event))
+			newRow, err = ParseMsgWithdrawDelegatorReward(address, event)
 		case staking.MsgDelegate:
-			rows = append(rows, ParseMsgWithdrawDelegatorReward(address, event))
+			newRow, err = ParseMsgWithdrawDelegatorReward(address, event)
 		case staking.MsgUndelegate:
-			rows = append(rows, ParseMsgWithdrawDelegatorReward(address, event))
+			newRow, err = ParseMsgWithdrawDelegatorReward(address, event)
 		case staking.MsgBeginRedelegate:
-			rows = append(rows, ParseMsgWithdrawDelegatorReward(address, event))
+			newRow, err = ParseMsgWithdrawDelegatorReward(address, event)
 		case gamm.MsgSwapExactAmountIn:
-			rows = append(rows, ParseMsgSwapExactAmountIn(address, event))
+			newRow, err = ParseMsgSwapExactAmountIn(address, event)
 		case gamm.MsgSwapExactAmountOut:
-			rows = append(rows, ParseMsgSwapExactAmountOut(address, event))
+			newRow, err = ParseMsgSwapExactAmountOut(address, event)
 		case gov.MsgSubmitProposal:
-			rows = append(rows, ParseMsgSubmitProposal(address, event))
+			newRow, err = ParseMsgSubmitProposal(address, event)
 		case gov.MsgDeposit:
-			rows = append(rows, ParseMsgDeposit(address, event))
+			newRow, err = ParseMsgDeposit(address, event)
 		case ibc.MsgTransfer:
-			rows = append(rows, ParseMsgTransfer(address, event))
+			newRow, err = ParseMsgTransfer(address, event)
 		default:
 			return nil, fmt.Errorf("no parser for message type '%v'", event.Message.MessageType.MessageType)
 		}
+
+		if err != nil {
+			return nil, fmt.Errorf("error parsing message type '%v'", event.Message.MessageType.MessageType)
+		}
+
+		rows = append(rows, newRow)
 	}
 	return rows, nil
 }
@@ -193,80 +201,80 @@ func ParseTx(address string, events []db.TaxableTransaction) (rows []parsers.Csv
 // ParseMsgSend:
 // If the address we searched is the receiver, then this transaction is a deposit.
 // If the address we searched is the sender, then this transaction is a withdrawal.
-func ParseMsgSend(address string, event db.TaxableTransaction) Row {
+func ParseMsgSend(address string, event db.TaxableTransaction) (Row, error) {
 	row := &Row{}
 	err := row.ParseBasic(address, event)
 	if err != nil {
-		config.Log.Fatal("Error with ParseMsgSend.", err)
+		config.Log.Error("Error with ParseMsgSend.", err)
 	}
-	return *row
+	return *row, err
 }
 
-func ParseMsgMultiSend(address string, event db.TaxableTransaction) Row {
+func ParseMsgMultiSend(address string, event db.TaxableTransaction) (Row, error) {
 	row := &Row{}
 	err := row.ParseBasic(address, event)
 	if err != nil {
-		config.Log.Fatal("Error with ParseMsgMultiSend.", err)
+		config.Log.Error("Error with ParseMsgMultiSend.", err)
 	}
-	return *row
+	return *row, err
 }
 
 // ParseMsgValidatorWithdraw:
 // This transaction is always a withdrawal.
-func ParseMsgWithdrawValidatorCommission(address string, event db.TaxableTransaction) Row {
+func ParseMsgWithdrawValidatorCommission(address string, event db.TaxableTransaction) (Row, error) {
 	row := &Row{}
 	err := row.ParseBasic(address, event)
 	if err != nil {
-		config.Log.Fatal("Error with ParseMsgWithdrawValidatorCommission.", err)
+		config.Log.Error("Error with ParseMsgWithdrawValidatorCommission.", err)
 	}
 	// row.Label = Unstake
-	return *row
+	return *row, err
 }
 
-func ParseMsgWithdrawDelegatorReward(address string, event db.TaxableTransaction) Row {
+func ParseMsgWithdrawDelegatorReward(address string, event db.TaxableTransaction) (Row, error) {
 	row := &Row{}
 	err := row.ParseBasic(address, event)
 	if err != nil {
-		config.Log.Fatal("Error with ParseMsgWithdrawDelegatorReward.", err)
+		config.Log.Error("Error with ParseMsgWithdrawDelegatorReward.", err)
 	}
 	// row.Label = Unstake
-	return *row
+	return *row, err
 }
 
-func ParseMsgFundCommunityPool(address string, event db.TaxableTransaction) Row {
+func ParseMsgFundCommunityPool(address string, event db.TaxableTransaction) (Row, error) {
 	row := &Row{}
 	err := row.ParseBasic(address, event)
 	if err != nil {
-		config.Log.Fatal("Error with ParseMsgFundCommunityPool.", err)
+		config.Log.Error("Error with ParseMsgFundCommunityPool.", err)
 	}
-	return *row
+	return *row, err
 }
 
-func ParseMsgSubmitProposal(address string, event db.TaxableTransaction) Row {
+func ParseMsgSubmitProposal(address string, event db.TaxableTransaction) (Row, error) {
 	row := &Row{}
 	err := row.ParseBasic(address, event)
 	if err != nil {
-		config.Log.Fatal("Error with ParseMsgSubmitProposal.", err)
+		config.Log.Error("Error with ParseMsgSubmitProposal.", err)
 	}
-	return *row
+	return *row, err
 }
 
-func ParseMsgDeposit(address string, event db.TaxableTransaction) Row {
+func ParseMsgDeposit(address string, event db.TaxableTransaction) (Row, error) {
 	row := &Row{}
 	err := row.ParseBasic(address, event)
 	if err != nil {
-		config.Log.Fatal("Error with ParseMsgDeposit.", err)
+		config.Log.Error("Error with ParseMsgDeposit.", err)
 	}
-	return *row
+	return *row, err
 }
 
-func ParseMsgTransfer(address string, event db.TaxableTransaction) Row {
+func ParseMsgTransfer(address string, event db.TaxableTransaction) (Row, error) {
 	row := &Row{}
 	err := row.ParseBasic(address, event)
 	if err != nil {
-		config.Log.Fatal("Error with ParseMsgTransfer.", err)
+		config.Log.Error("Error with ParseMsgTransfer.", err)
 	}
-	return *row
+	return *row, err
 }
 
 func (p *Parser) InitializeParsingGroups() {
@@ -282,20 +290,20 @@ func ParseOsmosisReward(event db.TaxableEvent) (Row, error) {
 	return *row, err
 }
 
-func ParseMsgSwapExactAmountIn(address string, event db.TaxableTransaction) Row {
+func ParseMsgSwapExactAmountIn(address string, event db.TaxableTransaction) (Row, error) {
 	row := &Row{}
 	err := row.ParseSwap(event, address, Buy)
 	if err != nil {
-		config.Log.Fatal("Error with ParseMsgSwapExactAmountIn.", err)
+		config.Log.Error("Error with ParseMsgSwapExactAmountIn.", err)
 	}
-	return *row
+	return *row, err
 }
 
-func ParseMsgSwapExactAmountOut(address string, event db.TaxableTransaction) Row {
+func ParseMsgSwapExactAmountOut(address string, event db.TaxableTransaction) (Row, error) {
 	row := &Row{}
 	err := row.ParseSwap(event, address, Sell)
 	if err != nil {
-		config.Log.Fatal("Error with ParseMsgSwapExactAmountOut.", err)
+		config.Log.Error("Error with ParseMsgSwapExactAmountOut.", err)
 	}
-	return *row
+	return *row, err
 }

--- a/csv/parsers/cryptotaxcalculator/cryptotaxcalculator.go
+++ b/csv/parsers/cryptotaxcalculator/cryptotaxcalculator.go
@@ -64,7 +64,7 @@ func (p *Parser) ProcessTaxableEvent(taxableEvents []db.TaxableEvent) error {
 	return nil
 }
 
-func (p *Parser) GetRows(address string, startDate, endDate *time.Time) []parsers.CsvRow {
+func (p *Parser) GetRows(address string, startDate, endDate *time.Time) ([]parsers.CsvRow, error) {
 	// Combine all normal rows and parser group rows into 1
 	cryptoRows := p.Rows // contains TX rows and fees as well as taxable events
 	for _, v := range p.ParsingGroups {
@@ -112,7 +112,7 @@ func (p *Parser) GetRows(address string, startDate, endDate *time.Time) []parser
 		csvRows[i] = v
 	}
 
-	return csvRows
+	return csvRows, nil
 }
 
 func (p Parser) GetHeaders() []string {

--- a/csv/parsers/cryptotaxcalculator/cryptotaxcalculator.go
+++ b/csv/parsers/cryptotaxcalculator/cryptotaxcalculator.go
@@ -156,7 +156,7 @@ func ParseEvent(event db.TaxableEvent) (rows []Row, err error) {
 func ParseTx(address string, events []db.TaxableTransaction) (rows []parsers.CsvRow, err error) {
 	for _, event := range events {
 		var newRow Row
-		var err error = nil
+		var err error
 		switch event.Message.MessageType.MessageType {
 		case bank.MsgSendV0:
 			newRow, err = ParseMsgSend(address, event)

--- a/csv/parsers/koinly/koinly.go
+++ b/csv/parsers/koinly/koinly.go
@@ -279,143 +279,151 @@ func ParseEvent(event db.TaxableEvent) (rows []Row) {
 // Use TX Parsing Groups to parse txes as a group
 func ParseTx(address string, events []db.TaxableTransaction) (rows []parsers.CsvRow, err error) {
 	for _, event := range events {
+		var newRow Row
+		var err error = nil
 		switch event.Message.MessageType.MessageType {
 		case bank.MsgSendV0:
-			rows = append(rows, ParseMsgSend(address, event))
+			newRow, err = ParseMsgSend(address, event)
 		case bank.MsgSend:
-			rows = append(rows, ParseMsgSend(address, event))
+			newRow, err = ParseMsgSend(address, event)
 		case bank.MsgMultiSendV0:
-			rows = append(rows, ParseMsgMultiSend(address, event))
+			newRow, err = ParseMsgMultiSend(address, event)
 		case bank.MsgMultiSend:
-			rows = append(rows, ParseMsgMultiSend(address, event))
+			newRow, err = ParseMsgMultiSend(address, event)
 		case distribution.MsgFundCommunityPool:
-			rows = append(rows, ParseMsgFundCommunityPool(address, event))
+			newRow, err = ParseMsgFundCommunityPool(address, event)
 		case distribution.MsgWithdrawValidatorCommission:
-			rows = append(rows, ParseMsgWithdrawValidatorCommission(address, event))
+			newRow, err = ParseMsgWithdrawValidatorCommission(address, event)
 		case distribution.MsgWithdrawRewards:
-			rows = append(rows, ParseMsgWithdrawDelegatorReward(address, event))
+			newRow, err = ParseMsgWithdrawDelegatorReward(address, event)
 		case distribution.MsgWithdrawDelegatorReward:
-			rows = append(rows, ParseMsgWithdrawDelegatorReward(address, event))
+			newRow, err = ParseMsgWithdrawDelegatorReward(address, event)
 		case staking.MsgDelegate:
-			rows = append(rows, ParseMsgWithdrawDelegatorReward(address, event))
+			newRow, err = ParseMsgWithdrawDelegatorReward(address, event)
 		case staking.MsgUndelegate:
-			rows = append(rows, ParseMsgWithdrawDelegatorReward(address, event))
+			newRow, err = ParseMsgWithdrawDelegatorReward(address, event)
 		case staking.MsgBeginRedelegate:
-			rows = append(rows, ParseMsgWithdrawDelegatorReward(address, event))
+			newRow, err = ParseMsgWithdrawDelegatorReward(address, event)
 		case gamm.MsgSwapExactAmountIn:
-			rows = append(rows, ParseMsgSwapExactAmountIn(event))
+			newRow, err = ParseMsgSwapExactAmountIn(event)
 		case gamm.MsgSwapExactAmountOut:
-			rows = append(rows, ParseMsgSwapExactAmountOut(event))
+			newRow, err = ParseMsgSwapExactAmountOut(event)
 		case ibc.MsgTransfer:
-			rows = append(rows, ParseMsgTransfer(address, event))
+			newRow, err = ParseMsgTransfer(address, event)
 		case gov.MsgSubmitProposal:
-			rows = append(rows, ParseMsgSubmitProposal(address, event))
+			newRow, err = ParseMsgSubmitProposal(address, event)
 		case gov.MsgDeposit:
-			rows = append(rows, ParseMsgDeposit(address, event))
+			newRow, err = ParseMsgDeposit(address, event)
 		default:
 			return nil, fmt.Errorf("no parser for message type '%v'", event.Message.MessageType.MessageType)
 		}
+
+		if err != nil {
+			return nil, fmt.Errorf("error parsing message type '%v'", event.Message.MessageType.MessageType)
+		}
+
+		rows = append(rows, newRow)
 	}
 	return rows, nil
 }
 
 // ParseMsgValidatorWithdraw:
 // This transaction is always a withdrawal.
-func ParseMsgWithdrawValidatorCommission(address string, event db.TaxableTransaction) Row {
+func ParseMsgWithdrawValidatorCommission(address string, event db.TaxableTransaction) (Row, error) {
 	row := &Row{}
 	err := row.ParseBasic(address, event)
 	if err != nil {
-		config.Log.Fatal("Error with ParseMsgWithdrawValidatorCommission.", err)
+		config.Log.Error("Error with ParseMsgWithdrawValidatorCommission.", err)
 	}
 	row.Label = Unstake
-	return *row
+	return *row, err
 }
 
 // ParseMsgValidatorWithdraw:
 // This transaction is always a withdrawal.
-func ParseMsgWithdrawDelegatorReward(address string, event db.TaxableTransaction) Row {
+func ParseMsgWithdrawDelegatorReward(address string, event db.TaxableTransaction) (Row, error) {
 	row := &Row{}
 	err := row.ParseBasic(address, event)
 	if err != nil {
-		config.Log.Fatal("Error with ParseMsgWithdrawDelegatorReward.", err)
+		config.Log.Error("Error with ParseMsgWithdrawDelegatorReward.", err)
 	}
 	row.Label = Unstake
-	return *row
+	return *row, err
 }
 
 // ParseMsgSend:
 // If the address we searched is the receiver, then this transaction is a deposit.
 // If the address we searched is the sender, then this transaction is a withdrawal.
-func ParseMsgSend(address string, event db.TaxableTransaction) Row {
+func ParseMsgSend(address string, event db.TaxableTransaction) (Row, error) {
 	row := &Row{}
 	err := row.ParseBasic(address, event)
 	if err != nil {
-		config.Log.Fatal("Error with ParseMsgSend.", err)
+		config.Log.Error("Error with ParseMsgSend.", err)
 	}
-	return *row
+	return *row, err
 }
 
-func ParseMsgMultiSend(address string, event db.TaxableTransaction) Row {
+func ParseMsgMultiSend(address string, event db.TaxableTransaction) (Row, error) {
 	row := &Row{}
 	err := row.ParseBasic(address, event)
 	if err != nil {
-		config.Log.Fatal("Error with ParseMsgMultiSend.", err)
+		config.Log.Error("Error with ParseMsgMultiSend.", err)
 	}
-	return *row
+	return *row, err
 }
 
-func ParseMsgFundCommunityPool(address string, event db.TaxableTransaction) Row {
+func ParseMsgFundCommunityPool(address string, event db.TaxableTransaction) (Row, error) {
 	row := &Row{}
 	err := row.ParseBasic(address, event)
 	if err != nil {
-		config.Log.Fatal("Error with ParseMsgFundCommunityPool.", err)
+		config.Log.Error("Error with ParseMsgFundCommunityPool.", err)
 	}
-	return *row
+	return *row, err
 }
 
-func ParseMsgSwapExactAmountIn(event db.TaxableTransaction) Row {
+func ParseMsgSwapExactAmountIn(event db.TaxableTransaction) (Row, error) {
 	row := &Row{}
 	err := row.ParseSwap(event)
 	if err != nil {
-		config.Log.Fatal("Error with ParseMsgSwapExactAmountIn.", err)
+		config.Log.Error("Error with ParseMsgSwapExactAmountIn.", err)
 	}
-	return *row
+	return *row, err
 }
 
-func ParseMsgSwapExactAmountOut(event db.TaxableTransaction) Row {
+func ParseMsgSwapExactAmountOut(event db.TaxableTransaction) (Row, error) {
 	row := &Row{}
 	err := row.ParseSwap(event)
 	if err != nil {
-		config.Log.Fatal("Error with ParseMsgSwapExactAmountOut.", err)
+		config.Log.Error("Error with ParseMsgSwapExactAmountOut.", err)
 	}
-	return *row
+	return *row, err
 }
 
-func ParseMsgTransfer(address string, event db.TaxableTransaction) Row {
+func ParseMsgTransfer(address string, event db.TaxableTransaction) (Row, error) {
 	row := &Row{}
 	err := row.ParseBasic(address, event)
 	if err != nil {
-		config.Log.Fatal("Error with ParseMsgTransfer.", err)
+		config.Log.Error("Error with ParseMsgTransfer.", err)
 	}
-	return *row
+	return *row, err
 }
 
-func ParseMsgSubmitProposal(address string, event db.TaxableTransaction) Row {
+func ParseMsgSubmitProposal(address string, event db.TaxableTransaction) (Row, error) {
 	row := &Row{}
 	err := row.ParseBasic(address, event)
 	if err != nil {
-		config.Log.Fatal("Error with ParseMsgSubmitProposal.", err)
+		config.Log.Error("Error with ParseMsgSubmitProposal.", err)
 	}
-	return *row
+	return *row, err
 }
 
-func ParseMsgDeposit(address string, event db.TaxableTransaction) Row {
+func ParseMsgDeposit(address string, event db.TaxableTransaction) (Row, error) {
 	row := &Row{}
 	err := row.ParseBasic(address, event)
 	if err != nil {
-		config.Log.Fatal("Error with ParseMsgDeposit.", err)
+		config.Log.Error("Error with ParseMsgDeposit.", err)
 	}
-	return *row
+	return *row, err
 }
 
 func ParseOsmosisReward(event db.TaxableEvent) (Row, error) {

--- a/csv/parsers/koinly/koinly.go
+++ b/csv/parsers/koinly/koinly.go
@@ -93,7 +93,11 @@ func (p *Parser) ProcessTaxableEvent(taxableEvents []db.TaxableEvent) error {
 	// Parse all the potentially taxable events
 	for _, event := range taxableEvents {
 		// generate the rows for the CSV.
-		p.Rows = append(p.Rows, ParseEvent(event)...)
+		rows, err := ParseEvent(event)
+		if err != nil {
+			return err
+		}
+		p.Rows = append(p.Rows, rows...)
 	}
 
 	return nil
@@ -264,16 +268,17 @@ func HandleFees(address string, events []db.TaxableTransaction) (rows []Row, err
 }
 
 // ParseEvent: Parse the potentially taxable event
-func ParseEvent(event db.TaxableEvent) (rows []Row) {
+func ParseEvent(event db.TaxableEvent) (rows []Row, err error) {
 	if event.Source == db.OsmosisRewardDistribution {
 		row, err := ParseOsmosisReward(event)
 		if err != nil {
-			config.Log.Fatal("error parsing row. Should be impossible to reach this condition, ideally (once all bugs worked out)", err)
+			config.Log.Error("error parsing row. Should be impossible to reach this condition, ideally (once all bugs worked out)", err)
+			return nil, err
 		}
 		rows = append(rows, row)
 	}
 
-	return rows
+	return rows, nil
 }
 
 // ParseTx: Parse the potentially taxable TX and Messages
@@ -432,7 +437,7 @@ func ParseOsmosisReward(event db.TaxableEvent) (Row, error) {
 	row := &Row{}
 	err := row.EventParseBasic(event)
 	if err != nil {
-		config.Log.Fatal("Error with ParseOsmosisReward.", err)
+		config.Log.Error("Error with ParseOsmosisReward.", err)
 	}
 	return *row, err
 }

--- a/csv/parsers/koinly/koinly.go
+++ b/csv/parsers/koinly/koinly.go
@@ -103,7 +103,7 @@ func (p *Parser) InitializeParsingGroups() {
 	p.ParsingGroups = append(p.ParsingGroups, parsers.GetOsmosisTxParsingGroups()...)
 }
 
-func (p *Parser) GetRows(address string, startDate, endDate *time.Time) []parsers.CsvRow {
+func (p *Parser) GetRows(address string, startDate, endDate *time.Time) ([]parsers.CsvRow, error) {
 	// Combine all normal rows and parser group rows into 1
 	koinlyRows := p.Rows // contains TX rows and fees as well as taxable events
 	for _, v := range p.ParsingGroups {
@@ -153,7 +153,8 @@ func (p *Parser) GetRows(address string, startDate, endDate *time.Time) []parser
 		if startDate != nil && firstToKeep == nil {
 			rowDate, err := time.Parse(TimeLayout, koinlyRows[i].Date)
 			if err != nil {
-				config.Log.Fatal("Error parsing row date.", err)
+				config.Log.Error("Error parsing row date.", err)
+				return nil, err
 			}
 			if rowDate.Before(*startDate) {
 				continue
@@ -163,7 +164,8 @@ func (p *Parser) GetRows(address string, startDate, endDate *time.Time) []parser
 		} else if endDate != nil && lastToKeep == nil {
 			rowDate, err := time.Parse(TimeLayout, koinlyRows[i].Date)
 			if err != nil {
-				config.Log.Fatal("Error parsing row date.", err)
+				config.Log.Error("Error parsing row date.", err)
+				return nil, err
 			}
 			if rowDate.Before(*endDate) {
 				continue
@@ -196,7 +198,7 @@ func (p *Parser) GetRows(address string, startDate, endDate *time.Time) []parser
 
 		csvRows[i] = v
 	}
-	return csvRows
+	return csvRows, nil
 }
 
 // mapUnsupportedCoints will create a map of unsupported coins to be replaced with NULL

--- a/csv/parsers/koinly/koinly.go
+++ b/csv/parsers/koinly/koinly.go
@@ -287,7 +287,7 @@ func ParseEvent(event db.TaxableEvent) (rows []Row, err error) {
 func ParseTx(address string, events []db.TaxableTransaction) (rows []parsers.CsvRow, err error) {
 	for _, event := range events {
 		var newRow Row
-		var err error = nil
+		var err error
 		switch event.Message.MessageType.MessageType {
 		case bank.MsgSendV0:
 			newRow, err = ParseMsgSend(address, event)

--- a/csv/parsers/taxbit/taxbit.go
+++ b/csv/parsers/taxbit/taxbit.go
@@ -68,7 +68,11 @@ func (p *Parser) ProcessTaxableEvent(taxableEvents []db.TaxableEvent) error {
 	// Parse all the potentially taxable events
 	for _, event := range taxableEvents {
 		// generate the rows for the CSV.
-		p.Rows = append(p.Rows, ParseEvent(event)...)
+		rows, err := ParseEvent(event)
+		if err != nil {
+			return err
+		}
+		p.Rows = append(p.Rows, rows...)
 	}
 
 	return nil
@@ -195,16 +199,17 @@ func HandleFees(address string, events []db.TaxableTransaction) (rows []Row, err
 }
 
 // ParseEvent: Parse the potentially taxable event
-func ParseEvent(event db.TaxableEvent) (rows []Row) {
+func ParseEvent(event db.TaxableEvent) (rows []Row, err error) {
 	if event.Source == db.OsmosisRewardDistribution {
 		row, err := ParseOsmosisReward(event)
 		if err != nil {
-			config.Log.Fatal("error parsing row. Should be impossible to reach this condition, ideally (once all bugs worked out)", err)
+			config.Log.Error("error parsing row. Should be impossible to reach this condition, ideally (once all bugs worked out)", err)
+			return nil, err
 		}
 		rows = append(rows, row)
 	}
 
-	return rows
+	return rows, nil
 }
 
 // ParseTx: Parse the potentially taxable TX and Messages
@@ -363,7 +368,7 @@ func ParseOsmosisReward(event db.TaxableEvent) (Row, error) {
 	row := &Row{}
 	err := row.EventParseBasic(event)
 	if err != nil {
-		config.Log.Fatal("Error with ParseOsmosisReward.", err)
+		config.Log.Error("Error with ParseOsmosisReward.", err)
 	}
 	return *row, err
 }

--- a/csv/parsers/taxbit/taxbit.go
+++ b/csv/parsers/taxbit/taxbit.go
@@ -218,7 +218,7 @@ func ParseEvent(event db.TaxableEvent) (rows []Row, err error) {
 func ParseTx(address string, events []db.TaxableTransaction) (rows []parsers.CsvRow, err error) {
 	for _, event := range events {
 		var newRow Row
-		var err error = nil
+		var err error
 		switch event.Message.MessageType.MessageType {
 		case bank.MsgSendV0:
 			newRow, err = ParseMsgSend(address, event)

--- a/csv/parsers/taxbit/taxbit.go
+++ b/csv/parsers/taxbit/taxbit.go
@@ -210,143 +210,151 @@ func ParseEvent(event db.TaxableEvent) (rows []Row) {
 // Use TX Parsing Groups to parse txes as a group
 func ParseTx(address string, events []db.TaxableTransaction) (rows []parsers.CsvRow, err error) {
 	for _, event := range events {
+		var newRow Row
+		var err error = nil
 		switch event.Message.MessageType.MessageType {
 		case bank.MsgSendV0:
-			rows = append(rows, ParseMsgSend(address, event))
+			newRow, err = ParseMsgSend(address, event)
 		case bank.MsgSend:
-			rows = append(rows, ParseMsgSend(address, event))
+			newRow, err = ParseMsgSend(address, event)
 		case bank.MsgMultiSendV0:
-			rows = append(rows, ParseMsgMultiSend(address, event))
+			newRow, err = ParseMsgMultiSend(address, event)
 		case bank.MsgMultiSend:
-			rows = append(rows, ParseMsgMultiSend(address, event))
+			newRow, err = ParseMsgMultiSend(address, event)
 		case distribution.MsgFundCommunityPool:
-			rows = append(rows, ParseMsgFundCommunityPool(address, event))
+			newRow, err = ParseMsgFundCommunityPool(address, event)
 		case distribution.MsgWithdrawValidatorCommission:
-			rows = append(rows, ParseMsgWithdrawValidatorCommission(address, event))
+			newRow, err = ParseMsgWithdrawValidatorCommission(address, event)
 		case distribution.MsgWithdrawRewards:
-			rows = append(rows, ParseMsgWithdrawDelegatorReward(address, event))
+			newRow, err = ParseMsgWithdrawDelegatorReward(address, event)
 		case distribution.MsgWithdrawDelegatorReward:
-			rows = append(rows, ParseMsgWithdrawDelegatorReward(address, event))
+			newRow, err = ParseMsgWithdrawDelegatorReward(address, event)
 		case staking.MsgDelegate:
-			rows = append(rows, ParseMsgWithdrawDelegatorReward(address, event))
+			newRow, err = ParseMsgWithdrawDelegatorReward(address, event)
 		case staking.MsgUndelegate:
-			rows = append(rows, ParseMsgWithdrawDelegatorReward(address, event))
+			newRow, err = ParseMsgWithdrawDelegatorReward(address, event)
 		case staking.MsgBeginRedelegate:
-			rows = append(rows, ParseMsgWithdrawDelegatorReward(address, event))
+			newRow, err = ParseMsgWithdrawDelegatorReward(address, event)
 		case gov.MsgSubmitProposal:
-			rows = append(rows, ParseMsgSubmitProposal(address, event))
+			newRow, err = ParseMsgSubmitProposal(address, event)
 		case gamm.MsgSwapExactAmountIn:
-			rows = append(rows, ParseMsgSwapExactAmountIn(event))
+			newRow, err = ParseMsgSwapExactAmountIn(event)
 		case gamm.MsgSwapExactAmountOut:
-			rows = append(rows, ParseMsgSwapExactAmountOut(event))
+			newRow, err = ParseMsgSwapExactAmountOut(event)
 		case gov.MsgDeposit:
-			rows = append(rows, ParseMsgDeposit(address, event))
+			newRow, err = ParseMsgDeposit(address, event)
 		case ibc.MsgTransfer:
-			rows = append(rows, ParseMsgTransfer(address, event))
+			newRow, err = ParseMsgTransfer(address, event)
 		default:
 			return nil, fmt.Errorf("no parser for message type '%v'", event.Message.MessageType.MessageType)
 		}
+
+		if err != nil {
+			return nil, fmt.Errorf("error parsing message type '%v'", event.Message.MessageType.MessageType)
+		}
+
+		rows = append(rows, newRow)
 	}
 	return rows, nil
 }
 
 // ParseMsgValidatorWithdraw:
 // This transaction is always a withdrawal.
-func ParseMsgWithdrawValidatorCommission(address string, event db.TaxableTransaction) Row {
+func ParseMsgWithdrawValidatorCommission(address string, event db.TaxableTransaction) (Row, error) {
 	row := &Row{}
 	err := row.ParseBasic(address, event)
 	if err != nil {
-		config.Log.Fatal("Error with ParseMsgWithdrawValidatorCommission.", err)
+		config.Log.Error("Error with ParseMsgWithdrawValidatorCommission.", err)
 	}
 	// row.Label = Unstake
-	return *row
+	return *row, err
 }
 
 // ParseMsgValidatorWithdraw:
 // This transaction is always a withdrawal.
-func ParseMsgWithdrawDelegatorReward(address string, event db.TaxableTransaction) Row {
+func ParseMsgWithdrawDelegatorReward(address string, event db.TaxableTransaction) (Row, error) {
 	row := &Row{}
 	err := row.ParseBasic(address, event)
 	if err != nil {
-		config.Log.Fatal("Error with ParseMsgWithdrawDelegatorReward.", err)
+		config.Log.Error("Error with ParseMsgWithdrawDelegatorReward.", err)
 	}
 	// row.Label = Unstake
-	return *row
+	return *row, err
 }
 
 // ParseMsgSend:
 // If the address we searched is the receiver, then this transaction is a deposit.
 // If the address we searched is the sender, then this transaction is a withdrawal.
-func ParseMsgSend(address string, event db.TaxableTransaction) Row {
+func ParseMsgSend(address string, event db.TaxableTransaction) (Row, error) {
 	row := &Row{}
 	err := row.ParseBasic(address, event)
 	if err != nil {
-		config.Log.Fatal("Error with ParseMsgSend.", err)
+		config.Log.Error("Error with ParseMsgSend.", err)
 	}
-	return *row
+	return *row, err
 }
 
-func ParseMsgMultiSend(address string, event db.TaxableTransaction) Row {
+func ParseMsgMultiSend(address string, event db.TaxableTransaction) (Row, error) {
 	row := &Row{}
 	err := row.ParseBasic(address, event)
 	if err != nil {
-		config.Log.Fatal("Error with ParseMsgMultiSend.", err)
+		config.Log.Error("Error with ParseMsgMultiSend.", err)
 	}
-	return *row
+	return *row, err
 }
 
-func ParseMsgFundCommunityPool(address string, event db.TaxableTransaction) Row {
+func ParseMsgFundCommunityPool(address string, event db.TaxableTransaction) (Row, error) {
 	row := &Row{}
 	err := row.ParseBasic(address, event)
 	if err != nil {
-		config.Log.Fatal("Error with ParseMsgFundCommunityPool.", err)
+		config.Log.Error("Error with ParseMsgFundCommunityPool.", err)
 	}
-	return *row
+	return *row, err
 }
 
-func ParseMsgSwapExactAmountIn(event db.TaxableTransaction) Row {
+func ParseMsgSwapExactAmountIn(event db.TaxableTransaction) (Row, error) {
 	row := &Row{}
 	err := row.ParseSwap(event)
 	if err != nil {
-		config.Log.Fatal("Error with ParseMsgSwapExactAmountIn.", err)
+		config.Log.Error("Error with ParseMsgSwapExactAmountIn.", err)
 	}
-	return *row
+	return *row, err
 }
 
-func ParseMsgSwapExactAmountOut(event db.TaxableTransaction) Row {
+func ParseMsgSwapExactAmountOut(event db.TaxableTransaction) (Row, error) {
 	row := &Row{}
 	err := row.ParseSwap(event)
 	if err != nil {
-		config.Log.Fatal("Error with ParseMsgSwapExactAmountOut.", err)
+		config.Log.Error("Error with ParseMsgSwapExactAmountOut.", err)
 	}
-	return *row
+	return *row, err
 }
 
-func ParseMsgTransfer(address string, event db.TaxableTransaction) Row {
+func ParseMsgTransfer(address string, event db.TaxableTransaction) (Row, error) {
 	row := &Row{}
 	err := row.ParseBasic(address, event)
 	if err != nil {
-		config.Log.Fatal("Error with ParseMsgTransfer.", err)
+		config.Log.Error("Error with ParseMsgTransfer.", err)
 	}
-	return *row
+	return *row, err
 }
 
-func ParseMsgSubmitProposal(address string, event db.TaxableTransaction) Row {
+func ParseMsgSubmitProposal(address string, event db.TaxableTransaction) (Row, error) {
 	row := &Row{}
 	err := row.ParseBasic(address, event)
 	if err != nil {
-		config.Log.Fatal("Error with ParseMsgSubmitProposal.", err)
+		config.Log.Error("Error with ParseMsgSubmitProposal.", err)
 	}
-	return *row
+	return *row, err
 }
 
-func ParseMsgDeposit(address string, event db.TaxableTransaction) Row {
+func ParseMsgDeposit(address string, event db.TaxableTransaction) (Row, error) {
 	row := &Row{}
 	err := row.ParseBasic(address, event)
 	if err != nil {
-		config.Log.Fatal("Error with ParseMsgDeposit.", err)
+		config.Log.Error("Error with ParseMsgDeposit.", err)
 	}
-	return *row
+	return *row, err
 }
 
 func ParseOsmosisReward(event db.TaxableEvent) (Row, error) {

--- a/csv/parsers/taxbit/taxbit.go
+++ b/csv/parsers/taxbit/taxbit.go
@@ -78,7 +78,7 @@ func (p *Parser) InitializeParsingGroups() {
 	p.ParsingGroups = append(p.ParsingGroups, parsers.GetOsmosisTxParsingGroups()...)
 }
 
-func (p *Parser) GetRows(address string, startDate, endDate *time.Time) []parsers.CsvRow {
+func (p *Parser) GetRows(address string, startDate, endDate *time.Time) ([]parsers.CsvRow, error) {
 	// Combine all normal rows and parser group rows into 1
 	taxbitRows := p.Rows // contains TX rows and fees as well as taxable events
 	for _, v := range p.ParsingGroups {
@@ -109,7 +109,8 @@ func (p *Parser) GetRows(address string, startDate, endDate *time.Time) []parser
 		if startDate != nil && firstToKeep == nil {
 			rowDate, err := time.Parse(TimeLayout, taxbitRows[i].Date)
 			if err != nil {
-				config.Log.Fatal("Error parsing row date.", err)
+				config.Log.Error("Error parsing row date.", err)
+				return nil, err
 			}
 			if rowDate.Before(*startDate) {
 				continue
@@ -119,7 +120,8 @@ func (p *Parser) GetRows(address string, startDate, endDate *time.Time) []parser
 		} else if endDate != nil && lastToKeep == nil {
 			rowDate, err := time.Parse(TimeLayout, taxbitRows[i].Date)
 			if err != nil {
-				config.Log.Fatal("Error parsing row date.", err)
+				config.Log.Error("Error parsing row date.", err)
+				return nil, err
 			}
 			if rowDate.Before(*endDate) {
 				continue
@@ -144,7 +146,7 @@ func (p *Parser) GetRows(address string, startDate, endDate *time.Time) []parser
 		csvRows[i] = v
 	}
 
-	return csvRows
+	return csvRows, nil
 }
 
 func (p Parser) GetHeaders() []string {

--- a/csv/parsers/types.go
+++ b/csv/parsers/types.go
@@ -11,7 +11,7 @@ type Parser interface {
 	ProcessTaxableTx(address string, taxableTxs []db.TaxableTransaction) error
 	ProcessTaxableEvent(taxableEvents []db.TaxableEvent) error
 	GetHeaders() []string
-	GetRows(address string, startDate, endDate *time.Time) []CsvRow
+	GetRows(address string, startDate, endDate *time.Time) ([]CsvRow, error)
 	TimeLayout() string
 }
 

--- a/csv/writer.go
+++ b/csv/writer.go
@@ -3,25 +3,27 @@ package csv
 import (
 	"bytes"
 	"encoding/csv"
-	"log"
 
+	"github.com/DefiantLabs/cosmos-tax-cli/config"
 	"github.com/DefiantLabs/cosmos-tax-cli/csv/parsers"
 )
 
 // Create the CSV and write it to byte buffer
-func ToCsv(rows []parsers.CsvRow, headers []string) bytes.Buffer {
+func ToCsv(rows []parsers.CsvRow, headers []string) (bytes.Buffer, error) {
 	var b bytes.Buffer
 	w := csv.NewWriter(&b)
 
 	if err := w.Write(headers); err != nil {
-		log.Fatalln("error writing header to csv:", err)
+		config.Log.Error("Error writing header to csv", err)
+		return b, err
 	}
 
 	// write the accointing rows to the csv
 	for _, row := range rows {
 		csvForRow := row.GetRowForCsv()
 		if err := w.Write(csvForRow); err != nil {
-			log.Fatalln("error writing record to csv:", err)
+			config.Log.Error("Error writing header to csv", err)
+			return b, err
 		}
 	}
 
@@ -29,8 +31,9 @@ func ToCsv(rows []parsers.CsvRow, headers []string) bytes.Buffer {
 	w.Flush()
 
 	if err := w.Error(); err != nil {
-		log.Fatal(err)
+		config.Log.Error("Error writing header to csv", err)
+		return b, err
 	}
 
-	return b
+	return b, nil
 }

--- a/test/indexer_test.go
+++ b/test/indexer_test.go
@@ -35,7 +35,12 @@ func TestOsmosisCsvForAddress(t *testing.T) {
 		t.Fatal("Failed to lookup taxable events")
 	}
 
-	buffer := csv.ToCsv(csvRows, headers)
+	buffer, err := csv.ToCsv(csvRows, headers)
+
+	if err != nil {
+		t.Fatal("CSV writing should not result in error", err)
+	}
+
 	if len(buffer.Bytes()) == 0 {
 		t.Fatal("CSV length should never be 0, there are always headers!")
 	}
@@ -63,7 +68,10 @@ func TestCsvForAddress(t *testing.T) {
 		t.Fatal("Failed to lookup taxable events")
 	}
 
-	buffer := csv.ToCsv(csvRows, headers)
+	buffer, err := csv.ToCsv(csvRows, headers)
+	if err != nil {
+		t.Fatal("CSV writing should not result in error", err)
+	}
 	if len(buffer.Bytes()) == 0 {
 		t.Fatal("CSV length should never be 0, there are always headers!")
 	}

--- a/test/indexer_test.go
+++ b/test/indexer_test.go
@@ -36,7 +36,6 @@ func TestOsmosisCsvForAddress(t *testing.T) {
 	}
 
 	buffer, err := csv.ToCsv(csvRows, headers)
-
 	if err != nil {
 		t.Fatal("CSV writing should not result in error", err)
 	}


### PR DESCRIPTION
This PR removes the Fatal error calls from the `csv/` codebase. These Fatal calls were resulting in a crashed API server basically every time something went wrong. We are instead going to do the following for all errors downstream of the API server:

1. Log the error
2. Return it to the caller
3. Process it in the caller, passing it all the way back up to the API server
4. Return 500 Internal Server responses to the client

Closes #405 