### PR TITLE
feat: index acks to determine outbound ibc transfer success

### DIFF
--- a/core/tx.go
+++ b/core/tx.go
@@ -50,7 +50,6 @@ var messageTypeHandler = map[string][]func() txtypes.CosmosMessage{
 	staking.MsgDelegate:                         {func() txtypes.CosmosMessage { return &staking.WrapperMsgDelegate{} }},
 	staking.MsgUndelegate:                       {func() txtypes.CosmosMessage { return &staking.WrapperMsgUndelegate{} }},
 	staking.MsgBeginRedelegate:                  {func() txtypes.CosmosMessage { return &staking.WrapperMsgBeginRedelegate{} }},
-	ibc.MsgTransfer:                             {func() txtypes.CosmosMessage { return &ibc.WrapperMsgTransfer{} }},
 	ibc.MsgRecvPacket:                           {func() txtypes.CosmosMessage { return &ibc.WrapperMsgRecvPacket{} }},
 	ibc.MsgAcknowledgement:                      {func() txtypes.CosmosMessage { return &ibc.WrapperMsgAcknowledgement{} }},
 }
@@ -70,6 +69,7 @@ var messageTypeIgnorer = map[string]interface{}{
 	// Voting is not taxable
 	gov.MsgVote: nil,
 	// The IBC msgs below do not create taxable events
+	ibc.MsgTransfer:              nil,
 	ibc.MsgUpdateClient:          nil,
 	ibc.MsgTimeout:               nil,
 	ibc.MsgTimeoutOnClose:        nil,

--- a/core/tx.go
+++ b/core/tx.go
@@ -52,6 +52,7 @@ var messageTypeHandler = map[string][]func() txtypes.CosmosMessage{
 	staking.MsgBeginRedelegate:                  {func() txtypes.CosmosMessage { return &staking.WrapperMsgBeginRedelegate{} }},
 	ibc.MsgTransfer:                             {func() txtypes.CosmosMessage { return &ibc.WrapperMsgTransfer{} }},
 	ibc.MsgRecvPacket:                           {func() txtypes.CosmosMessage { return &ibc.WrapperMsgRecvPacket{} }},
+	ibc.MsgAcknowledgement:                      {func() txtypes.CosmosMessage { return &ibc.WrapperMsgAcknowledgement{} }},
 }
 
 // These messages are ignored for tax purposes.
@@ -70,8 +71,6 @@ var messageTypeIgnorer = map[string]interface{}{
 	gov.MsgVote: nil,
 	// The IBC msgs below do not create taxable events
 	ibc.MsgUpdateClient:          nil,
-	ibc.MsgAcknowledgement:       nil,
-	ibc.MsgRecvPacket:            nil,
 	ibc.MsgTimeout:               nil,
 	ibc.MsgTimeoutOnClose:        nil,
 	ibc.MsgCreateClient:          nil,

--- a/cosmos/modules/ibc/types.go
+++ b/cosmos/modules/ibc/types.go
@@ -14,9 +14,9 @@ import (
 const (
 	MsgRecvPacket      = "/ibc.core.channel.v1.MsgRecvPacket"
 	MsgAcknowledgement = "/ibc.core.channel.v1.MsgAcknowledgement"
-	MsgTransfer        = "/ibc.applications.transfer.v1.MsgTransfer"
 
 	// Explicitly ignored messages for tx parsing purposes
+	MsgTransfer           = "/ibc.applications.transfer.v1.MsgTransfer"
 	MsgChannelOpenTry     = "/ibc.core.channel.v1.MsgChannelOpenTry"
 	MsgChannelOpenConfirm = "/ibc.core.channel.v1.MsgChannelOpenConfirm"
 	MsgChannelOpenInit    = "/ibc.core.channel.v1.MsgChannelOpenInit"

--- a/cosmos/modules/ibc/types.go
+++ b/cosmos/modules/ibc/types.go
@@ -12,9 +12,9 @@ import (
 )
 
 const (
-	MsgTransfer        = "/ibc.applications.transfer.v1.MsgTransfer"
 	MsgRecvPacket      = "/ibc.core.channel.v1.MsgRecvPacket"
 	MsgAcknowledgement = "/ibc.core.channel.v1.MsgAcknowledgement"
+	MsgTransfer        = "/ibc.applications.transfer.v1.MsgTransfer"
 
 	// Explicitly ignored messages for tx parsing purposes
 	MsgChannelOpenTry     = "/ibc.core.channel.v1.MsgChannelOpenTry"
@@ -33,54 +33,6 @@ const (
 	MsgCreateClient = "/ibc.core.client.v1.MsgCreateClient"
 	MsgUpdateClient = "/ibc.core.client.v1.MsgUpdateClient"
 )
-
-type WrapperMsgTransfer struct {
-	txModule.Message
-	CosmosMsgTransfer *types.MsgTransfer
-	SenderAddress     string
-	ReceiverAddress   string
-	Amount            *stdTypes.Coin
-}
-
-// HandleMsg: Handle type checking for MsgFundCommunityPool
-func (sf *WrapperMsgTransfer) HandleMsg(msgType string, msg stdTypes.Msg, log *txModule.LogMessage) error {
-	sf.Type = msgType
-	sf.CosmosMsgTransfer = msg.(*types.MsgTransfer)
-
-	// Confirm that the action listed in the message log matches the Message type
-	validLog := txModule.IsMessageActionEquals(sf.GetType(), log)
-	if !validLog {
-		return util.ReturnInvalidLog(msgType, log)
-	}
-
-	// Funds sent and sender address are pulled from the parsed Cosmos Msg
-	sf.SenderAddress = sf.CosmosMsgTransfer.Sender
-	sf.ReceiverAddress = sf.CosmosMsgTransfer.Receiver
-	sf.Amount = &sf.CosmosMsgTransfer.Token
-
-	return nil
-}
-
-func (sf *WrapperMsgTransfer) ParseRelevantData() []parsingTypes.MessageRelevantInformation {
-	if sf.Amount != nil {
-		return []parsingTypes.MessageRelevantInformation{{
-			SenderAddress:        sf.SenderAddress,
-			ReceiverAddress:      sf.ReceiverAddress,
-			AmountSent:           sf.Amount.Amount.BigInt(),
-			AmountReceived:       sf.Amount.Amount.BigInt(),
-			DenominationSent:     sf.Amount.Denom,
-			DenominationReceived: sf.Amount.Denom,
-		}}
-	}
-	return nil
-}
-
-func (sf *WrapperMsgTransfer) String() string {
-	if sf.Amount == nil {
-		return fmt.Sprintf("MsgTransfer: IBC transfer from %s to %s did not include an amount", sf.SenderAddress, sf.ReceiverAddress)
-	}
-	return fmt.Sprintf("MsgTransfer: IBC transfer of %s from %s to %s", sf.CosmosMsgTransfer.Token, sf.SenderAddress, sf.ReceiverAddress)
-}
 
 type WrapperMsgRecvPacket struct {
 	txModule.Message

--- a/cosmos/modules/ibc/types.go
+++ b/cosmos/modules/ibc/types.go
@@ -6,15 +6,15 @@ import (
 	parsingTypes "github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules"
 	txModule "github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules/tx"
 	"github.com/DefiantLabs/cosmos-tax-cli/util"
+	stdTypes "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/ibc-go/v4/modules/apps/transfer/types"
 	chantypes "github.com/cosmos/ibc-go/v4/modules/core/04-channel/types"
-
-	stdTypes "github.com/cosmos/cosmos-sdk/types"
 )
 
 const (
-	MsgTransfer   = "/ibc.applications.transfer.v1.MsgTransfer"
-	MsgRecvPacket = "/ibc.core.channel.v1.MsgRecvPacket"
+	MsgTransfer        = "/ibc.applications.transfer.v1.MsgTransfer"
+	MsgRecvPacket      = "/ibc.core.channel.v1.MsgRecvPacket"
+	MsgAcknowledgement = "/ibc.core.channel.v1.MsgAcknowledgement"
 
 	// Explicitly ignored messages for tx parsing purposes
 	MsgChannelOpenTry     = "/ibc.core.channel.v1.MsgChannelOpenTry"
@@ -22,9 +22,8 @@ const (
 	MsgChannelOpenInit    = "/ibc.core.channel.v1.MsgChannelOpenInit"
 	MsgChannelOpenAck     = "/ibc.core.channel.v1.MsgChannelOpenAck"
 
-	MsgAcknowledgement = "/ibc.core.channel.v1.MsgAcknowledgement"
-	MsgTimeout         = "/ibc.core.channel.v1.MsgTimeout"
-	MsgTimeoutOnClose  = "/ibc.core.channel.v1.MsgTimeoutOnClose"
+	MsgTimeout        = "/ibc.core.channel.v1.MsgTimeout"
+	MsgTimeoutOnClose = "/ibc.core.channel.v1.MsgTimeoutOnClose"
 
 	MsgConnectionOpenTry     = "/ibc.core.connection.v1.MsgConnectionOpenTry"
 	MsgConnectionOpenConfirm = "/ibc.core.connection.v1.MsgConnectionOpenConfirm"
@@ -145,4 +144,84 @@ func (w *WrapperMsgRecvPacket) String() string {
 		return fmt.Sprintf("MsgRecvPacket: IBC transfer from %s to %s did not include an amount\n", w.SenderAddress, w.ReceiverAddress)
 	}
 	return fmt.Sprintf("MsgRecvPacket: IBC transfer of %s from %s to %s\n", w.Amount, w.SenderAddress, w.ReceiverAddress)
+}
+
+type WrapperMsgAcknowledgement struct {
+	txModule.Message
+	MsgAcknowledgement *chantypes.MsgAcknowledgement
+	Sequence           uint64
+	SenderAddress      string
+	ReceiverAddress    string
+	Amount             stdTypes.Coin
+}
+
+func (w *WrapperMsgAcknowledgement) HandleMsg(msgType string, msg stdTypes.Msg, log *txModule.LogMessage) error {
+	w.Type = msgType
+	w.MsgAcknowledgement = msg.(*chantypes.MsgAcknowledgement)
+
+	// Confirm that the action listed in the message log matches the Message type
+	validLog := txModule.IsMessageActionEquals(w.GetType(), log)
+	if !validLog {
+		return util.ReturnInvalidLog(msgType, log)
+	}
+
+	// Unmarshal the json encoded packet data so we can access sender, receiver and denom info
+	var data types.FungibleTokenPacketData
+	if err := types.ModuleCdc.UnmarshalJSON(w.MsgAcknowledgement.Packet.GetData(), &data); err != nil {
+		// If there was a failure then this ack was not for a token transfer packet,
+		// currently we only consider successful token transfers taxable events.
+		return err
+	}
+
+	w.SenderAddress = data.Sender
+	w.ReceiverAddress = data.Receiver
+	w.Sequence = w.MsgAcknowledgement.Packet.Sequence
+
+	amount, ok := stdTypes.NewIntFromString(data.Amount)
+	if !ok {
+		return fmt.Errorf("failed to convert denom amount to sdk.Int, got(%s)", data.Amount)
+	}
+
+	w.Amount = stdTypes.NewCoin(data.Denom, amount)
+
+	// Acknowledgements can contain an error & we only want to index successful acks,
+	// so we need to check the ack bytes to determine if it was a result or an error.
+	var ack chantypes.Acknowledgement
+	if err := types.ModuleCdc.UnmarshalJSON(w.MsgAcknowledgement.Acknowledgement, &ack); err != nil {
+		return fmt.Errorf("cannot unmarshal ICS-20 transfer packet acknowledgement: %v", err)
+	}
+
+	switch ack.Response.(type) {
+	case *chantypes.Acknowledgement_Error:
+		return fmt.Errorf("acknowledgement contained an error, %s", ack.Response)
+	default:
+		// the acknowledgement succeeded on the receiving chain
+		return nil
+	}
+}
+
+func (w *WrapperMsgAcknowledgement) ParseRelevantData() []parsingTypes.MessageRelevantInformation {
+	if w.Amount.IsNil() {
+		return nil
+	}
+
+	// MsgAcknowledgement indicates a user has successfully sent a packet
+	// so the received amount will always be zero
+	amountReceived := stdTypes.NewInt(0)
+
+	return []parsingTypes.MessageRelevantInformation{{
+		SenderAddress:        w.SenderAddress,
+		ReceiverAddress:      w.ReceiverAddress,
+		AmountSent:           w.Amount.Amount.BigInt(),
+		AmountReceived:       amountReceived.BigInt(),
+		DenominationSent:     w.Amount.Denom,
+		DenominationReceived: "",
+	}}
+}
+
+func (w *WrapperMsgAcknowledgement) String() string {
+	if w.Amount.IsNil() {
+		return fmt.Sprintf("MsgAcknowledgement: IBC transfer from %s to %s did not include an amount\n", w.SenderAddress, w.ReceiverAddress)
+	}
+	return fmt.Sprintf("MsgAcknowledgement: IBC transfer of %s from %s to %s\n", w.Amount, w.SenderAddress, w.ReceiverAddress)
 }


### PR DESCRIPTION
Currently we are indexing `MsgTransfer` to determine if some outbound ICS-20 transfer took place and a taxable event should be observed. The problem with this is that a transfer can fail or be timed out which means we cannot assume all occurrences of `MsgTransfer` indicate a successful outbound transfer. 

Instead we can index `MsgAcknowledgement` which indicates that the `OnRecvPacket` callback was invoked on the receiving chain. `Acknowledgements` can be either an `Acknowledgement_Error` or `Acknowledgement_Result` where the former indicates a failed transfer and the latter indicates a successful transfer, we only index `Acknowledgement_Result`.

Closes #406 