### PR TITLE
Classify MsgAck types and results and index only on successful transfers

### DIFF
--- a/cosmos/modules/ibc/types.go
+++ b/cosmos/modules/ibc/types.go
@@ -32,6 +32,15 @@ const (
 
 	MsgCreateClient = "/ibc.core.client.v1.MsgCreateClient"
 	MsgUpdateClient = "/ibc.core.client.v1.MsgUpdateClient"
+
+	// Consts used for classifying Ack messages
+	// We may need to keep extending these consts for other types
+	AckFungibleTokenTransfer    = 0
+	AckNotFungibleTokenTransfer = 1
+
+	// Same as above, we may want to to extend these to track other results
+	AckSuccess = 0
+	AckFailure = 1
 )
 
 type WrapperMsgRecvPacket struct {
@@ -78,6 +87,7 @@ func (w *WrapperMsgRecvPacket) HandleMsg(msgType string, msg stdTypes.Msg, log *
 }
 
 func (w *WrapperMsgRecvPacket) ParseRelevantData() []parsingTypes.MessageRelevantInformation {
+	// This prevents the item from being indexed
 	if w.Amount.IsNil() {
 		return nil
 	}
@@ -110,6 +120,8 @@ type WrapperMsgAcknowledgement struct {
 	ReceiverAddress    string
 	Amount             stdTypes.Int
 	Denom              string
+	AckType            int
+	AckResult          int
 }
 
 func (w *WrapperMsgAcknowledgement) HandleMsg(msgType string, msg stdTypes.Msg, log *txModule.LogMessage) error {
@@ -127,8 +139,11 @@ func (w *WrapperMsgAcknowledgement) HandleMsg(msgType string, msg stdTypes.Msg, 
 	if err := types.ModuleCdc.UnmarshalJSON(w.MsgAcknowledgement.Packet.GetData(), &data); err != nil {
 		// If there was a failure then this ack was not for a token transfer packet,
 		// currently we only consider successful token transfers taxable events.
+		w.AckType = AckNotFungibleTokenTransfer
 		return nil
 	}
+
+	w.AckType = AckFungibleTokenTransfer
 
 	w.SenderAddress = data.Sender
 	w.ReceiverAddress = data.Receiver
@@ -139,9 +154,6 @@ func (w *WrapperMsgAcknowledgement) HandleMsg(msgType string, msg stdTypes.Msg, 
 		return fmt.Errorf("failed to convert denom amount to sdk.Int, got(%s)", data.Amount)
 	}
 
-	w.Amount = amount
-	w.Denom = data.Denom
-
 	// Acknowledgements can contain an error & we only want to index successful acks,
 	// so we need to check the ack bytes to determine if it was a result or an error.
 	var ack chantypes.Acknowledgement
@@ -151,15 +163,21 @@ func (w *WrapperMsgAcknowledgement) HandleMsg(msgType string, msg stdTypes.Msg, 
 
 	switch ack.Response.(type) {
 	case *chantypes.Acknowledgement_Error:
-		return fmt.Errorf("acknowledgement contained an error, %s", ack.Response)
+		// We index nothing on Acknowledgement errors
+		w.AckResult = AckFailure
+		return nil
 	default:
 		// the acknowledgement succeeded on the receiving chain
+		w.AckResult = AckSuccess
+		w.Amount = amount
+		w.Denom = data.Denom
 		return nil
 	}
 }
 
 func (w *WrapperMsgAcknowledgement) ParseRelevantData() []parsingTypes.MessageRelevantInformation {
-	if w.Amount.IsNil() {
+	// This prevents the item from being indexed
+	if w.Amount.IsNil() || w.AckType == AckNotFungibleTokenTransfer || w.AckResult == AckFailure {
 		return nil
 	}
 
@@ -178,8 +196,17 @@ func (w *WrapperMsgAcknowledgement) ParseRelevantData() []parsingTypes.MessageRe
 }
 
 func (w *WrapperMsgAcknowledgement) String() string {
+	if w.AckType == AckNotFungibleTokenTransfer {
+		return "MsgAcknowledgement: IBC transfer was not a FungibleTokenTransfer"
+	}
+
+	if w.AckType == AckFungibleTokenTransfer && w.AckResult == AckFailure {
+		return "MsgAcknowledgement: IBC transfer was not successful"
+	}
+
 	if w.Amount.IsNil() {
 		return "MsgAcknowledgement: IBC transfer was not a FungibleTokenTransfer"
 	}
+
 	return fmt.Sprintf("MsgAcknowledgement: IBC transfer of %s%s from %s to %s\n", w.Amount, w.Denom, w.SenderAddress, w.ReceiverAddress)
 }


### PR DESCRIPTION
Extend Ack parser to classify ack type (fungible transfer vs otherwise) and ack result (success or not). Only index on successful fungible token transfers that succeeded