### PR TITLE
429 and 431 api ibc support and error handling

### DIFF
--- a/csv/parsers/accointing/accointing.go
+++ b/csv/parsers/accointing/accointing.go
@@ -256,11 +256,13 @@ func ParseTx(address string, events []db.TaxableTransaction) (rows []parsers.Csv
 		case ibc.MsgTransfer:
 			newRow, err = ParseMsgTransfer(address, event)
 		default:
-			return nil, fmt.Errorf("no parser for message type '%v'", event.Message.MessageType.MessageType)
+			config.Log.Errorf("no parser for message type '%v'", event.Message.MessageType.MessageType)
+			continue
 		}
 
 		if err != nil {
-			return nil, fmt.Errorf("error parsing message type '%v'", event.Message.MessageType.MessageType)
+			config.Log.Errorf("error parsing message type '%v': %v", event.Message.MessageType.MessageType, err)
+			continue
 		}
 
 		rows = append(rows, newRow)

--- a/csv/parsers/accointing/accointing.go
+++ b/csv/parsers/accointing/accointing.go
@@ -255,6 +255,10 @@ func ParseTx(address string, events []db.TaxableTransaction) (rows []parsers.Csv
 			newRow, err = ParseMsgDeposit(address, event)
 		case ibc.MsgTransfer:
 			newRow, err = ParseMsgTransfer(address, event)
+		case ibc.MsgAcknowledgement:
+			newRow, err = ParseMsgTransfer(address, event)
+		case ibc.MsgRecvPacket:
+			newRow, err = ParseMsgTransfer(address, event)
 		default:
 			config.Log.Errorf("no parser for message type '%v'", event.Message.MessageType.MessageType)
 			continue

--- a/csv/parsers/cointracker/cointracker.go
+++ b/csv/parsers/cointracker/cointracker.go
@@ -1,7 +1,6 @@
 package cointracker
 
 import (
-	"fmt"
 	"sort"
 	"time"
 
@@ -249,11 +248,13 @@ func ParseTx(address string, events []db.TaxableTransaction) (rows []parsers.Csv
 		case ibc.MsgTransfer:
 			newRow, err = ParseMsgTransfer(address, event)
 		default:
-			return nil, fmt.Errorf("no parser for message type '%v'", event.Message.MessageType.MessageType)
+			config.Log.Errorf("no parser for message type '%v'", event.Message.MessageType.MessageType)
+			continue
 		}
 
 		if err != nil {
-			return nil, fmt.Errorf("error parsing message type '%v'", event.Message.MessageType.MessageType)
+			config.Log.Errorf("error parsing message type '%v': %v", event.Message.MessageType.MessageType, err)
+			continue
 		}
 
 		rows = append(rows, newRow)

--- a/csv/parsers/cointracker/cointracker.go
+++ b/csv/parsers/cointracker/cointracker.go
@@ -247,6 +247,10 @@ func ParseTx(address string, events []db.TaxableTransaction) (rows []parsers.Csv
 			newRow, err = ParseMsgSwapExactAmountOut(event)
 		case ibc.MsgTransfer:
 			newRow, err = ParseMsgTransfer(address, event)
+		case ibc.MsgAcknowledgement:
+			newRow, err = ParseMsgTransfer(address, event)
+		case ibc.MsgRecvPacket:
+			newRow, err = ParseMsgTransfer(address, event)
 		default:
 			config.Log.Errorf("no parser for message type '%v'", event.Message.MessageType.MessageType)
 			continue

--- a/csv/parsers/cryptotaxcalculator/cryptotaxcalculator.go
+++ b/csv/parsers/cryptotaxcalculator/cryptotaxcalculator.go
@@ -189,6 +189,10 @@ func ParseTx(address string, events []db.TaxableTransaction) (rows []parsers.Csv
 			newRow, err = ParseMsgDeposit(address, event)
 		case ibc.MsgTransfer:
 			newRow, err = ParseMsgTransfer(address, event)
+		case ibc.MsgAcknowledgement:
+			newRow, err = ParseMsgTransfer(address, event)
+		case ibc.MsgRecvPacket:
+			newRow, err = ParseMsgTransfer(address, event)
 		default:
 			config.Log.Errorf("no parser for message type '%v'", event.Message.MessageType.MessageType)
 			continue

--- a/csv/parsers/cryptotaxcalculator/cryptotaxcalculator.go
+++ b/csv/parsers/cryptotaxcalculator/cryptotaxcalculator.go
@@ -1,7 +1,6 @@
 package cryptotaxcalculator
 
 import (
-	"fmt"
 	"sort"
 	"time"
 
@@ -191,11 +190,13 @@ func ParseTx(address string, events []db.TaxableTransaction) (rows []parsers.Csv
 		case ibc.MsgTransfer:
 			newRow, err = ParseMsgTransfer(address, event)
 		default:
-			return nil, fmt.Errorf("no parser for message type '%v'", event.Message.MessageType.MessageType)
+			config.Log.Errorf("no parser for message type '%v'", event.Message.MessageType.MessageType)
+			continue
 		}
 
 		if err != nil {
-			return nil, fmt.Errorf("error parsing message type '%v'", event.Message.MessageType.MessageType)
+			config.Log.Errorf("error parsing message type '%v': %v", event.Message.MessageType.MessageType, err)
+			continue
 		}
 
 		rows = append(rows, newRow)

--- a/csv/parsers/koinly/koinly.go
+++ b/csv/parsers/koinly/koinly.go
@@ -321,6 +321,10 @@ func ParseTx(address string, events []db.TaxableTransaction) (rows []parsers.Csv
 			newRow, err = ParseMsgSubmitProposal(address, event)
 		case gov.MsgDeposit:
 			newRow, err = ParseMsgDeposit(address, event)
+		case ibc.MsgAcknowledgement:
+			newRow, err = ParseMsgTransfer(address, event)
+		case ibc.MsgRecvPacket:
+			newRow, err = ParseMsgTransfer(address, event)
 		default:
 			config.Log.Errorf("no parser for message type '%v'", event.Message.MessageType.MessageType)
 			continue

--- a/csv/parsers/koinly/koinly.go
+++ b/csv/parsers/koinly/koinly.go
@@ -322,11 +322,13 @@ func ParseTx(address string, events []db.TaxableTransaction) (rows []parsers.Csv
 		case gov.MsgDeposit:
 			newRow, err = ParseMsgDeposit(address, event)
 		default:
-			return nil, fmt.Errorf("no parser for message type '%v'", event.Message.MessageType.MessageType)
+			config.Log.Errorf("no parser for message type '%v'", event.Message.MessageType.MessageType)
+			continue
 		}
 
 		if err != nil {
-			return nil, fmt.Errorf("error parsing message type '%v'", event.Message.MessageType.MessageType)
+			config.Log.Errorf("error parsing message type '%v': %v", event.Message.MessageType.MessageType, err)
+			continue
 		}
 
 		rows = append(rows, newRow)

--- a/csv/parsers/taxbit/taxbit.go
+++ b/csv/parsers/taxbit/taxbit.go
@@ -251,6 +251,10 @@ func ParseTx(address string, events []db.TaxableTransaction) (rows []parsers.Csv
 			newRow, err = ParseMsgDeposit(address, event)
 		case ibc.MsgTransfer:
 			newRow, err = ParseMsgTransfer(address, event)
+		case ibc.MsgAcknowledgement:
+			newRow, err = ParseMsgTransfer(address, event)
+		case ibc.MsgRecvPacket:
+			newRow, err = ParseMsgTransfer(address, event)
 		default:
 			config.Log.Errorf("no parser for message type '%v'", event.Message.MessageType.MessageType)
 			continue

--- a/csv/parsers/taxbit/taxbit.go
+++ b/csv/parsers/taxbit/taxbit.go
@@ -1,7 +1,6 @@
 package taxbit
 
 import (
-	"fmt"
 	"sort"
 	"time"
 
@@ -253,11 +252,13 @@ func ParseTx(address string, events []db.TaxableTransaction) (rows []parsers.Csv
 		case ibc.MsgTransfer:
 			newRow, err = ParseMsgTransfer(address, event)
 		default:
-			return nil, fmt.Errorf("no parser for message type '%v'", event.Message.MessageType.MessageType)
+			config.Log.Errorf("no parser for message type '%v'", event.Message.MessageType.MessageType)
+			continue
 		}
 
 		if err != nil {
-			return nil, fmt.Errorf("error parsing message type '%v'", event.Message.MessageType.MessageType)
+			config.Log.Errorf("error parsing message type '%v': %v", event.Message.MessageType.MessageType, err)
+			continue
 		}
 
 		rows = append(rows, newRow)


### PR DESCRIPTION
This is a patch for the following:

1. Add missing CSV parser support for the 2 new IBC events
2. Patch to eliminate a few classes of error returns so that the CSV can be returned but errors will appear in logs

Closes #429 
Closes #431 