### PR TITLE
feat: protorev dev rewards indexing

### DIFF
--- a/cmd/index.go
+++ b/cmd/index.go
@@ -106,7 +106,6 @@ func setupIndexer() *Indexer {
 
 	if idxr.cfg.Lens.ChainID == osmosis.ChainID && idxr.cfg.Base.EpochEventIndexingEnabled {
 		err := osmosis.SetupOsmosisEpochIndexer(idxr.cl)
-
 		if err != nil {
 			config.Log.Fatal("Error setting up Osmosis Epoch Indexer.", err)
 		}

--- a/cmd/index.go
+++ b/cmd/index.go
@@ -104,6 +104,14 @@ func setupIndexer() *Indexer {
 		config.Log.Fatal("Error querying chain status.", err)
 	}
 
+	if idxr.cfg.Lens.ChainID == osmosis.ChainID && idxr.cfg.Base.EpochEventIndexingEnabled {
+		err := osmosis.SetupOsmosisEpochIndexer(idxr.cl)
+
+		if err != nil {
+			config.Log.Fatal("Error setting up Osmosis Epoch Indexer.", err)
+		}
+	}
+
 	return &idxr
 }
 

--- a/db/models.go
+++ b/db/models.go
@@ -87,6 +87,7 @@ const (
 	TendermintLiquidityWithdrawPoolCoinSent
 	TendermintLiquidityWithdrawCoinReceived
 	TendermintLiquidityWithdrawFee
+	OsmosisProtorevDeveloperRewardDistribution
 )
 
 // An event does not necessarily need to be part of a Transaction. For example, Osmosis rewards.

--- a/go.mod
+++ b/go.mod
@@ -93,8 +93,6 @@ require (
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/btree v1.1.2 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
-	github.com/google/go-github v17.0.0+incompatible // indirect
-	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/orderedcode v0.0.1 // indirect
 	github.com/gorilla/handlers v1.5.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/BurntSushi/toml v1.2.1
 	// FYI, you can do go get github.com/DefiantLabs/lens@1f6f34841280df179c6e098f040bd584ced43a4c
 	// (using the commit hash from github) to pin to a specific commit.
-	github.com/DefiantLabs/lens v0.3.1-0.20230601224644-9babbffc163f
+	github.com/DefiantLabs/lens v0.3.1-0.20230610142309-fa4d6caee6cb
 	github.com/cosmos/cosmos-sdk v0.46.10
 	github.com/gin-gonic/gin v1.9.0
 	github.com/go-co-op/gocron v1.13.0
@@ -93,6 +93,8 @@ require (
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/btree v1.1.2 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
+	github.com/google/go-github v17.0.0+incompatible // indirect
+	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/orderedcode v0.0.1 // indirect
 	github.com/gorilla/handlers v1.5.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,6 @@ github.com/CosmWasm/wasmvm v1.1.1/go.mod h1:ei0xpvomwSdONsxDuONzV7bL1jSET1M8brEx
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/zstd v1.4.1/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/DataDog/zstd v1.4.5/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
-github.com/DefiantLabs/lens v0.3.1-0.20230601224644-9babbffc163f h1:l/3elgd9DvvDChIQshzf+XHxt+vT2e9q+6EUR2ZZqzI=
-github.com/DefiantLabs/lens v0.3.1-0.20230601224644-9babbffc163f/go.mod h1:iYXij2G8daws2xBOYNzyMNlasr7vJJTOJkVk7aXkMXw=
 github.com/DefiantLabs/lens v0.3.1-0.20230610142309-fa4d6caee6cb h1:lINTo5Ipuz3102sD/bNR3MOgj4k9/1jwF8wSTSWR6kI=
 github.com/DefiantLabs/lens v0.3.1-0.20230610142309-fa4d6caee6cb/go.mod h1:iYXij2G8daws2xBOYNzyMNlasr7vJJTOJkVk7aXkMXw=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
@@ -387,10 +385,6 @@ github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
-github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
-github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
-github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.1-0.20200604201612-c04b05f3adfa/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,8 @@ github.com/DataDog/zstd v1.4.1/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t
 github.com/DataDog/zstd v1.4.5/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/DefiantLabs/lens v0.3.1-0.20230601224644-9babbffc163f h1:l/3elgd9DvvDChIQshzf+XHxt+vT2e9q+6EUR2ZZqzI=
 github.com/DefiantLabs/lens v0.3.1-0.20230601224644-9babbffc163f/go.mod h1:iYXij2G8daws2xBOYNzyMNlasr7vJJTOJkVk7aXkMXw=
+github.com/DefiantLabs/lens v0.3.1-0.20230610142309-fa4d6caee6cb h1:lINTo5Ipuz3102sD/bNR3MOgj4k9/1jwF8wSTSWR6kI=
+github.com/DefiantLabs/lens v0.3.1-0.20230610142309-fa4d6caee6cb/go.mod h1:iYXij2G8daws2xBOYNzyMNlasr7vJJTOJkVk7aXkMXw=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc=
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
@@ -385,6 +387,10 @@ github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
+github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
+github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
+github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.1-0.20200604201612-c04b05f3adfa/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=

--- a/osmosis/epochs/protorev/types.go
+++ b/osmosis/epochs/protorev/types.go
@@ -1,9 +1,86 @@
 package protorev
 
+import (
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	abciTypes "github.com/tendermint/tendermint/abci/types"
+
+	"github.com/DefiantLabs/cosmos-tax-cli/cosmos/events"
+	dbTypes "github.com/DefiantLabs/cosmos-tax-cli/db"
+	osmosisEvents "github.com/DefiantLabs/cosmos-tax-cli/osmosis/events"
+)
+
 // protorevDeveloperAddress is the address of the developer account that receives rewards on the weekly Epoch.
 // This will need to be prepopulated by the indexer before module startup
 var protorevDeveloperAddress string
 
 func SetDeveloperAddress(address string) {
 	protorevDeveloperAddress = address
+}
+
+type WrapperBlockCoinReceived struct {
+	Event           abciTypes.Event
+	RewardsReceived sdk.Coins
+	ReceiverAddress string
+	ProtorevEvent   bool
+}
+
+func (sf *WrapperBlockCoinReceived) GetType() string {
+	return osmosisEvents.BlockEventDistribution
+}
+
+func (sf *WrapperBlockCoinReceived) HandleEvent(eventType string, event abciTypes.Event) error {
+	var receiverAddr string
+	var receiverAmount string
+
+	for _, attr := range event.Attributes {
+		if string(attr.Key) == "receiver" {
+			receiverAddr = string(attr.Value)
+		}
+		if string(attr.Key) == "amount" {
+			receiverAmount = string(attr.Value)
+		}
+	}
+
+	if receiverAddr != "" && receiverAmount != "" && receiverAddr == protorevDeveloperAddress {
+		coins, err := sdk.ParseCoinsNormalized(receiverAmount)
+		if err != nil {
+			return err
+		}
+		sf.ReceiverAddress = receiverAddr
+		sf.RewardsReceived = coins
+		sf.ProtorevEvent = true
+	} else {
+		sf.ProtorevEvent = false
+	}
+
+	return nil
+}
+
+func (sf *WrapperBlockCoinReceived) ParseRelevantData() []events.EventRelevantInformation {
+
+	if !sf.ProtorevEvent {
+		return nil
+	}
+
+	relevantData := make([]events.EventRelevantInformation, len(sf.RewardsReceived))
+
+	for i, coin := range sf.RewardsReceived {
+		relevantData[i] = events.EventRelevantInformation{
+			Address:      sf.ReceiverAddress,
+			Amount:       coin.Amount.BigInt(),
+			Denomination: coin.Denom,
+			EventSource:  dbTypes.OsmosisProtorevDeveloperRewardDistribution,
+		}
+	}
+
+	return relevantData
+}
+
+func (sf *WrapperBlockCoinReceived) String() string {
+	if !sf.ProtorevEvent {
+		return "Coin received event is not a Protorev event"
+	}
+	return fmt.Sprintf("Osmosis Protorev event %s: Address %s received %s rewards.", sf.GetType(), sf.ReceiverAddress, sf.RewardsReceived)
 }

--- a/osmosis/epochs/protorev/types.go
+++ b/osmosis/epochs/protorev/types.go
@@ -1,0 +1,9 @@
+package protorev
+
+// protorevDeveloperAddress is the address of the developer account that receives rewards on the weekly Epoch.
+// This will need to be prepopulated by the indexer before module startup
+var protorevDeveloperAddress string
+
+func SetDeveloperAddress(address string) {
+	protorevDeveloperAddress = address
+}

--- a/osmosis/epochs/protorev/types.go
+++ b/osmosis/epochs/protorev/types.go
@@ -59,7 +59,6 @@ func (sf *WrapperBlockCoinReceived) HandleEvent(eventType string, event abciType
 }
 
 func (sf *WrapperBlockCoinReceived) ParseRelevantData() []events.EventRelevantInformation {
-
 	if !sf.ProtorevEvent {
 		return nil
 	}

--- a/osmosis/epochs/types.go
+++ b/osmosis/epochs/types.go
@@ -3,6 +3,7 @@ package epochs
 import (
 	eventTypes "github.com/DefiantLabs/cosmos-tax-cli/cosmos/events"
 	incentivesEventTypes "github.com/DefiantLabs/cosmos-tax-cli/osmosis/epochs/incentives"
+	protorevEventTypes "github.com/DefiantLabs/cosmos-tax-cli/osmosis/epochs/protorev"
 	"github.com/DefiantLabs/cosmos-tax-cli/osmosis/events"
 	"github.com/DefiantLabs/cosmos-tax-cli/osmosis/modules/epochs"
 )
@@ -11,8 +12,17 @@ var dayBeginBlockEventTypesToHandlers = map[string][]func() eventTypes.CosmosEve
 	events.BlockEventDistribution: {func() eventTypes.CosmosEvent { return &incentivesEventTypes.WrapperBlockDistribution{} }},
 }
 
+var weekBeginBlockEventTypesToHandlers = map[string][]func() eventTypes.CosmosEvent{
+	events.BlockEventCoinReceived: {func() eventTypes.CosmosEvent { return &protorevEventTypes.WrapperBlockCoinReceived{} }},
+}
+
 var dayEventTypeHandlers = map[string]map[string][]func() eventTypes.CosmosEvent{
 	"begin_block": dayBeginBlockEventTypesToHandlers,
+	"end_block":   nil,
+}
+
+var weekEventTypeHandlers = map[string]map[string][]func() eventTypes.CosmosEvent{
+	"begin_block": weekBeginBlockEventTypesToHandlers,
 	"end_block":   nil,
 }
 
@@ -22,5 +32,6 @@ var dayEventTypeHandlers = map[string]map[string][]func() eventTypes.CosmosEvent
 // 2. CosmosHub begin blocker or end blocker events for
 // 3. A particular Event Type
 var EpochIdentifierBlockEventHandlers = map[string]map[string]map[string][]func() eventTypes.CosmosEvent{
-	epochs.DayEpochIdentifier: dayEventTypeHandlers,
+	epochs.DayEpochIdentifier:  dayEventTypeHandlers,
+	epochs.WeekEpochIdentifier: weekEventTypeHandlers,
 }

--- a/osmosis/events/types.go
+++ b/osmosis/events/types.go
@@ -2,4 +2,5 @@ package events
 
 const (
 	BlockEventDistribution = "distribution"
+	BlockEventCoinReceived = "coin_received"
 )

--- a/osmosis/setup.go
+++ b/osmosis/setup.go
@@ -13,7 +13,6 @@ func SetupOsmosisEpochIndexer(cl *client.ChainClient) error {
 	config.Log.Info("Gathering Protorev Developer Account Address")
 
 	resp, err := rpc.GetProtorevDeveloperAccount(cl)
-
 	if err != nil {
 		config.Log.Error("Error getting Protorev Developer Account Address", err)
 		return err

--- a/osmosis/setup.go
+++ b/osmosis/setup.go
@@ -1,0 +1,26 @@
+package osmosis
+
+import (
+	"github.com/DefiantLabs/cosmos-tax-cli/config"
+	"github.com/DefiantLabs/cosmos-tax-cli/osmosis/epochs/protorev"
+	"github.com/DefiantLabs/cosmos-tax-cli/rpc"
+	"github.com/DefiantLabs/lens/client"
+)
+
+// SetupOsmosisEpochIndexer sets up the indexer for the osmosis epoch indexing process
+func SetupOsmosisEpochIndexer(cl *client.ChainClient) error {
+	config.Log.Info("Setting up Osmosis Epoch Indexer")
+	config.Log.Info("Gathering Protorev Developer Account Address")
+
+	resp, err := rpc.GetProtorevDeveloperAccount(cl)
+
+	if err != nil {
+		config.Log.Error("Error getting Protorev Developer Account Address", err)
+		return err
+	}
+
+	protorev.SetDeveloperAddress(resp.DeveloperAccount)
+	config.Log.Debugf("Protorev Developer Account Address: %s", resp.DeveloperAccount)
+
+	return nil
+}

--- a/rpc/requests.go
+++ b/rpc/requests.go
@@ -6,6 +6,7 @@ import (
 	lensClient "github.com/DefiantLabs/lens/client"
 	lensQuery "github.com/DefiantLabs/lens/client/query"
 	lensEpochsTypes "github.com/DefiantLabs/lens/osmosis/x/epochs/types"
+	lensProtorevTypes "github.com/DefiantLabs/lens/osmosis/x/protorev/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
 	txTypes "github.com/cosmos/cosmos-sdk/types/tx"
 )
@@ -102,5 +103,13 @@ func GetEpochsAtHeight(cl *lensClient.ChainClient, height int64) (*lensEpochsTyp
 	options := lensQuery.QueryOptions{}
 	query := lensQuery.Query{Client: cl, Options: &options}
 	resp, err := query.EpochsAtHeight(height)
+	return resp, err
+}
+
+// GetEpochsAtHeight makes a request to the Cosmos RPC API and returns the Epoch at a specific height
+func GetProtorevDeveloperAccount(cl *lensClient.ChainClient) (*lensProtorevTypes.QueryGetProtoRevDeveloperAccountResponse, error) {
+	options := lensQuery.QueryOptions{}
+	query := lensQuery.Query{Client: cl, Options: &options}
+	resp, err := query.ProtorevDeveloperAccount()
 	return resp, err
 }


### PR DESCRIPTION
Adds the ability to index Protorev developer rewards events. It works like so:

1. Adds a pre-indexing setup step to get the Protorev Developer address directly from the RPC endpoint available in the module
2. Adds a week Epoch event handler for the coin_received event that:
   * Gets the recipient and amount
   * Compares the recipient address to the protorev developer address
   * Only indexes the event if it is the protorev dev address

This will prevent the event indexer from indexing random coin_received events that are not relevant to this module.

Closes #436