### PR TITLE
feat: Better logging during Block Event/Epoch DB inserts

### DIFF
--- a/db/events.go
+++ b/db/events.go
@@ -13,7 +13,7 @@ import (
 	"gorm.io/gorm"
 )
 
-func IndexBlockEvents(db *gorm.DB, dryRun bool, blockHeight int64, blockTime time.Time, blockEvents []events.EventRelevantInformation, dbChainID string, dbChainName string) error {
+func IndexBlockEvents(db *gorm.DB, dryRun bool, blockHeight int64, blockTime time.Time, blockEvents []events.EventRelevantInformation, dbChainID string, dbChainName string, identifierLoggingString string) error {
 	dbEvents := []TaxableEvent{}
 
 	for _, blockEvent := range blockEvents {
@@ -77,7 +77,7 @@ func IndexBlockEvents(db *gorm.DB, dryRun bool, blockHeight int64, blockTime tim
 		}
 
 		if !dryRun {
-			config.Log.Infof("Sending %d block events to DB %d/%d", len(awaitingInsert), currentIter, numIters)
+			config.Log.Infof("Sending %d block events to DB for %s %d/%d", len(awaitingInsert), identifierLoggingString, currentIter, numIters)
 			err := createTaxableEvents(db, awaitingInsert)
 			if err != nil {
 				config.Log.Error("Error storing DB events.", err)


### PR DESCRIPTION
Add building of identifier logging string for block and epoch event d…b processing, use when printing info logs for easier tracking

Closes #452 

This results in the following output for Epoch 774 on Osmosis:

```
3:27PM INF Indexing 199715 Block Events from block 10800166 for epoch 774 in epoch identifier day
3:27PM INF Sending 10000 block events to DB for epoch 774 in epoch identifier day 1/20
3:27PM INF Sending 10000 block events to DB for epoch 774 in epoch identifier day 2/20
3:27PM INF Sending 10000 block events to DB for epoch 774 in epoch identifier day 3/20
3:27PM INF Sending 10000 block events to DB for epoch 774 in epoch identifier day 4/20
3:27PM INF Sending 10000 block events to DB for epoch 774 in epoch identifier day 5/20
3:27PM INF Sending 10000 block events to DB for epoch 774 in epoch identifier day 6/20
3:27PM INF Sending 10000 block events to DB for epoch 774 in epoch identifier day 7/20
3:27PM INF Sending 10000 block events to DB for epoch 774 in epoch identifier day 8/20
3:27PM INF Sending 10000 block events to DB for epoch 774 in epoch identifier day 9/20
3:27PM INF Sending 10000 block events to DB for epoch 774 in epoch identifier day 10/20
3:27PM INF Sending 10000 block events to DB for epoch 774 in epoch identifier day 11/20
3:27PM INF Sending 10000 block events to DB for epoch 774 in epoch identifier day 12/20
3:27PM INF Sending 10000 block events to DB for epoch 774 in epoch identifier day 13/20
3:27PM INF Sending 10000 block events to DB for epoch 774 in epoch identifier day 14/20
3:27PM INF Sending 10000 block events to DB for epoch 774 in epoch identifier day 15/20
3:28PM INF Sending 10000 block events to DB for epoch 774 in epoch identifier day 16/20
3:28PM INF Sending 10000 block events to DB for epoch 774 in epoch identifier day 17/20
3:28PM INF Sending 10000 block events to DB for epoch 774 in epoch identifier day 18/20
3:28PM INF Sending 10000 block events to DB for epoch 774 in epoch identifier day 19/20
3:28PM INF Sending 9715 block events to DB for epoch 774 in epoch identifier day 20/20
```

This will help with output watching so that logs can be matched up to the processes happening on them