### PR TITLE
patch/MsgCreateBalancerPool Support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/BurntSushi/toml v1.2.1
 	// FYI, you can do go get github.com/DefiantLabs/lens@1f6f34841280df179c6e098f040bd584ced43a4c
 	// (using the commit hash from github) to pin to a specific commit.
-	github.com/DefiantLabs/lens v0.3.1-0.20230722165648-8d2ea08319c2
+	github.com/DefiantLabs/lens v0.3.1-0.20230821220122-64e495f632d6
 	github.com/cosmos/cosmos-sdk v0.47.3
 	github.com/gin-gonic/gin v1.9.1
 	github.com/go-co-op/gocron v1.13.0

--- a/go.sum
+++ b/go.sum
@@ -60,8 +60,8 @@ github.com/CosmWasm/wasmvm v1.2.3/go.mod h1:vW/E3h8j9xBQs9bCoijDuawKo9kCtxOaS8N8
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/zstd v1.5.0/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
-github.com/DefiantLabs/lens v0.3.1-0.20230722165648-8d2ea08319c2 h1:E4JNMrw4V3rDM8Z+li74X0BpzEnsD2ie0SbvZXWmlB8=
-github.com/DefiantLabs/lens v0.3.1-0.20230722165648-8d2ea08319c2/go.mod h1:AfrSD4ARamOR6kfAle3oFlVGebljdrnuasvlTVrBdM0=
+github.com/DefiantLabs/lens v0.3.1-0.20230821220122-64e495f632d6 h1:fndtLD4b5gLZMW0pm2FUupf1qqfIW51lLVz/AToj6g4=
+github.com/DefiantLabs/lens v0.3.1-0.20230821220122-64e495f632d6/go.mod h1:AfrSD4ARamOR6kfAle3oFlVGebljdrnuasvlTVrBdM0=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc=
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=

--- a/osmosis/handlers.go
+++ b/osmosis/handlers.go
@@ -18,6 +18,7 @@ var MessageTypeHandler = map[string][]func() txTypes.CosmosMessage{
 	gamm.MsgExitSwapExternAmountOut:                 {func() txTypes.CosmosMessage { return &gamm.WrapperMsgExitSwapExternAmountOut{} }},
 	gamm.MsgExitPool:                                {func() txTypes.CosmosMessage { return &gamm.WrapperMsgExitPool{} }, func() txTypes.CosmosMessage { return &gamm.WrapperMsgExitPool2{} }},
 	gamm.MsgCreatePool:                              {func() txTypes.CosmosMessage { return &gamm.WrapperMsgCreatePool{} }, func() txTypes.CosmosMessage { return &gamm.WrapperMsgCreatePool2{} }},
+	gamm.MsgCreateBalancerPool:                      {func() txTypes.CosmosMessage { return &gamm.WrapperMsgCreateBalancerPool{} }},
 	poolmanager.MsgSwapExactAmountIn:                {func() txTypes.CosmosMessage { return &poolmanager.WrapperMsgSwapExactAmountIn{} }},
 	poolmanager.MsgSwapExactAmountOut:               {func() txTypes.CosmosMessage { return &poolmanager.WrapperMsgSwapExactAmountOut{} }},
 	concentratedliquidity.MsgCreatePosition:         {func() txTypes.CosmosMessage { return &concentratedliquidity.WrapperMsgCreatePosition{} }},

--- a/osmosis/modules/gamm/types.go
+++ b/osmosis/modules/gamm/types.go
@@ -25,6 +25,7 @@ const (
 	MsgExitSwapExternAmountOut = "/osmosis.gamm.v1beta1.MsgExitSwapExternAmountOut"
 	MsgExitPool                = "/osmosis.gamm.v1beta1.MsgExitPool"
 	MsgCreatePool              = "/osmosis.gamm.v1beta1.MsgCreatePool"
+	MsgCreateBalancerPool      = "/osmosis.gamm.v1beta1.MsgCreateBalancerPool"
 )
 
 const (
@@ -156,6 +157,14 @@ type WrapperMsgCreatePool struct {
 	OtherCoinsReceived   []coinReceived // e.g. from claims module (airdrops)
 }
 
+type WrapperMsgCreateBalancerPool struct {
+	txModule.Message
+	OsmosisMsgCreateBalancerPool *osmosisOldTypes.MsgCreateBalancerPool
+	CoinsSpent                   []sdk.Coin
+	GammCoinsReceived            sdk.Coin
+	OtherCoinsReceived           []coinReceived // e.g. from claims module (airdrops)
+}
+
 type coinReceived struct {
 	sender       string
 	coinReceived sdk.Coin
@@ -262,6 +271,17 @@ func (sf *WrapperMsgCreatePool) String() string {
 
 func (sf *WrapperMsgCreatePool2) String() string {
 	return sf.WrapperMsgCreatePool.String()
+}
+
+func (sf *WrapperMsgCreateBalancerPool) String() string {
+	var tokensIn []string
+	if !(len(sf.OsmosisMsgCreateBalancerPool.PoolAssets) == 0) {
+		for _, v := range sf.OsmosisMsgCreateBalancerPool.PoolAssets {
+			tokensIn = append(tokensIn, v.Token.String())
+		}
+	}
+	return fmt.Sprintf("MsgCreateBalancerPool: %s created pool with %s",
+		sf.OsmosisMsgCreateBalancerPool.Sender, strings.Join(tokensIn, ", "))
 }
 
 func (sf *WrapperMsgExitSwapShareAmountIn) String() string {
@@ -1068,6 +1088,67 @@ func (sf *WrapperMsgCreatePool2) HandleMsg(msgType string, msg sdk.Msg, log *txM
 	return nil
 }
 
+func (sf *WrapperMsgCreateBalancerPool) HandleMsg(msgType string, msg sdk.Msg, log *txModule.LogMessage) error {
+	sf.Type = msgType
+	sf.OsmosisMsgCreateBalancerPool = msg.(*osmosisOldTypes.MsgCreateBalancerPool)
+
+	// Confirm that the action listed in the message log matches the Message type
+	validLog := txModule.IsMessageActionEquals(sf.GetType(), log)
+	if !validLog {
+		return util.ReturnInvalidLog(msgType, log)
+	}
+
+	coinSpentEvents := txModule.GetEventsWithType(bankTypes.EventTypeCoinSpent, log)
+	if len(coinSpentEvents) == 0 {
+		return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
+	}
+
+	coinsSpent := txModule.GetCoinsSpent(sf.OsmosisMsgCreateBalancerPool.Sender, coinSpentEvents)
+
+	if len(coinsSpent) < 2 {
+		return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("invalid number of coins spent: %+v", log)}
+	}
+
+	sf.CoinsSpent = []sdk.Coin{}
+	for _, coin := range coinsSpent {
+		t, err := sdk.ParseCoinNormalized(coin)
+		if err != nil {
+			return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
+		}
+
+		sf.CoinsSpent = append(sf.CoinsSpent, t)
+	}
+
+	coinReceivedEvents := txModule.GetEventsWithType(bankTypes.EventTypeCoinReceived, log)
+	if len(coinReceivedEvents) == 0 {
+		return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
+	}
+
+	coinsReceived := txModule.GetCoinsReceived(sf.OsmosisMsgCreateBalancerPool.Sender, coinReceivedEvents)
+
+	gammCoinsReceived := []string{}
+
+	for _, coin := range coinsReceived {
+		if strings.Contains(coin, "gamm/pool") {
+			gammCoinsReceived = append(gammCoinsReceived, coin)
+		} else {
+			return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("unexpected non-gamm/pool coin received: %+v", log)}
+		}
+	}
+
+	if len(gammCoinsReceived) != 1 {
+		return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("invalid number of coins received: %+v", log)}
+	}
+
+	var err error
+	sf.GammCoinsReceived, err = sdk.ParseCoinNormalized(gammCoinsReceived[0])
+	if err != nil {
+		return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
+	}
+
+	return err
+}
+
 func (sf *WrapperMsgExitSwapShareAmountIn) HandleMsg(msgType string, msg sdk.Msg, log *txModule.LogMessage) error {
 	sf.Type = msgType
 	sf.OsmosisMsgExitSwapShareAmountIn = msg.(*gammTypes.MsgExitSwapShareAmountIn)
@@ -1507,6 +1588,52 @@ func (sf *WrapperMsgCreatePool) ParseRelevantData() []parsingTypes.MessageReleva
 			DenominationReceived: c.coinReceived.Denom,
 			SenderAddress:        c.sender,
 			ReceiverAddress:      sf.OsmosisMsgCreatePool.Sender,
+		}
+		i++
+	}
+
+	return relevantData
+}
+
+func (sf *WrapperMsgCreateBalancerPool) ParseRelevantData() []parsingTypes.MessageRelevantInformation {
+	// need to make a relevant data block for all Tokens sent to the pool on creation
+	relevantData := make([]parsingTypes.MessageRelevantInformation, len(sf.CoinsSpent)+len(sf.OtherCoinsReceived))
+
+	// figure out how many gams per token
+	nthGamms, remainderGamms := calcNthGams(sf.GammCoinsReceived.Amount.BigInt(), len(sf.CoinsSpent))
+	for i, v := range sf.CoinsSpent {
+		// split received tokens across entry so we receive GAMM tokens for both exchanges
+		// each swap will get 1 nth of the gams until the last one which will get the remainder
+		if i != len(sf.CoinsSpent)-1 {
+			relevantData[i] = parsingTypes.MessageRelevantInformation{
+				AmountSent:           v.Amount.BigInt(),
+				DenominationSent:     v.Denom,
+				AmountReceived:       nthGamms,
+				DenominationReceived: sf.GammCoinsReceived.Denom,
+				SenderAddress:        sf.OsmosisMsgCreateBalancerPool.Sender,
+				ReceiverAddress:      sf.OsmosisMsgCreateBalancerPool.Sender,
+			}
+		} else {
+			relevantData[i] = parsingTypes.MessageRelevantInformation{
+				AmountSent:           v.Amount.BigInt(),
+				DenominationSent:     v.Denom,
+				AmountReceived:       remainderGamms,
+				DenominationReceived: sf.GammCoinsReceived.Denom,
+				SenderAddress:        sf.OsmosisMsgCreateBalancerPool.Sender,
+				ReceiverAddress:      sf.OsmosisMsgCreateBalancerPool.Sender,
+			}
+		}
+	}
+
+	i := len(sf.CoinsSpent)
+	for _, c := range sf.OtherCoinsReceived {
+		relevantData[i] = parsingTypes.MessageRelevantInformation{
+			AmountSent:           c.coinReceived.Amount.BigInt(),
+			DenominationSent:     c.coinReceived.Denom,
+			AmountReceived:       c.coinReceived.Amount.BigInt(),
+			DenominationReceived: c.coinReceived.Denom,
+			SenderAddress:        c.sender,
+			ReceiverAddress:      sf.OsmosisMsgCreateBalancerPool.Sender,
 		}
 		i++
 	}


### PR DESCRIPTION
Update Lens package to new commit that supports MsgCreateBalancerPool, add parsers and handlers for parsing this message type.

This PR adds:

1. An updated Lens version to a commit that provides support for RPC parsing of the message type
2. Parsers and handlers that handle the new message type

Tested on block 4314620:

```
DBG [Block: 4314620] Cosmos message of known type: MsgCreateBalancerPool: osmo1s0dkfgfql5wv9vj4p87pdky25rh357y5n8sd3u created pool with 100000000ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC, 49700730052195933224ibc/F292A17CF920E3462C816CBE6B042E779F676CAB59096904C4C1C966413E3DF5, 62713402311390977349ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7, 99095452ibc/9F9B07EF9AD291167CF5700628145DE1DEB777C2CFC7907553B24446515F6D0E, 99199302ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858, 104027707ibc/8242AD24008032E457D2E12D46588FD39FB54FB29680C6C7663D296B383C37C4, 100209567736390066261ibc/0E43EDE2E2A3AFA36D0CD38BDDC0B49FECA64FA426A82E102F304E430ECF46EE
```