### PR TITLE
Add IBC channel closing message types to taxable event ignore list

### DIFF
--- a/core/tx.go
+++ b/core/tx.go
@@ -83,6 +83,8 @@ var messageTypeIgnorer = map[string]interface{}{
 	ibc.MsgConnectionOpenAck:     nil,
 	ibc.MsgChannelOpenInit:       nil,
 	ibc.MsgChannelOpenAck:        nil,
+	ibc.MsgChannelCloseConfirm:   nil,
+	ibc.MsgChannelCloseInit:      nil,
 	// Creating and modifying gauges does not create taxable events
 	incentives.MsgCreateGauge: nil,
 	incentives.MsgAddToGauge:  nil,

--- a/cosmos/modules/ibc/types.go
+++ b/cosmos/modules/ibc/types.go
@@ -30,6 +30,9 @@ const (
 	MsgConnectionOpenInit    = "/ibc.core.connection.v1.MsgConnectionOpenInit"
 	MsgConnectionOpenAck     = "/ibc.core.connection.v1.MsgConnectionOpenAck"
 
+	MsgChannelCloseConfirm = "/ibc.core.channel.v1.MsgChannelCloseConfirm"
+	MsgChannelCloseInit    = "/ibc.core.channel.v1.MsgChannelCloseInit"
+
 	MsgCreateClient = "/ibc.core.client.v1.MsgCreateClient"
 	MsgUpdateClient = "/ibc.core.client.v1.MsgUpdateClient"
 


### PR DESCRIPTION
Closing a channel is done with 2 Message types, we are adding these to the ignore list so fees are the only things parsed.