### PR TITLE
Feat/469 epoch indexer tracking

### DIFF
--- a/cmd/update_epochs.go
+++ b/cmd/update_epochs.go
@@ -63,7 +63,7 @@ func updateEpochs(cmd *cobra.Command, args []string) {
 			currentHeight := latestHeight
 
 			for {
-				lastIndexedEpoch, foundLast := indexEpochsAtStartingHeight(db, cl, currentHeight, chain, cfg.Base.Throttling)
+				lastIndexedEpoch, foundLast := indexEpochsAtStartingHeight(db, cl, currentHeight, chain, epochIdentifier, cfg.Base.Throttling)
 
 				if lastIndexedEpoch.EpochNumber <= 1 || foundLast {
 					config.Log.Infof("Indexed earliest possible Epoch through Epoch querying method")
@@ -125,7 +125,7 @@ func updateEpochs(cmd *cobra.Command, args []string) {
 	}
 }
 
-func indexEpochsAtStartingHeight(db *gorm.DB, cl *client.ChainClient, startingHeight int64, chain dbTypes.Chain, throttling float64) (*dbTypes.Epoch, bool) {
+func indexEpochsAtStartingHeight(db *gorm.DB, cl *client.ChainClient, startingHeight int64, chain dbTypes.Chain, identifierToIndex string, throttling float64) (*dbTypes.Epoch, bool) {
 	currentHeight := startingHeight
 	var lastIndexedItem dbTypes.Epoch
 	for {
@@ -148,7 +148,7 @@ func indexEpochsAtStartingHeight(db *gorm.DB, cl *client.ChainClient, startingHe
 			// Make sure we have the ability to index this EpochInfo
 			// This will save us trouble if Osmosis adds more Epochs in the future
 			indexable, identifierExists := epochsTypes.OsmosisIndexableEpochs[epoch.Identifier]
-			if identifierExists && indexable && epoch.Identifier == epochIdentifier {
+			if identifierExists && indexable && epoch.Identifier == identifierToIndex {
 
 				if epoch.CurrentEpochStartHeight <= 0 {
 					config.Log.Debugf("Found Epoch %d that contains 0 for CurrentEpochStartHeight, cannot continue", epoch.CurrentEpoch)

--- a/db/events.go
+++ b/db/events.go
@@ -90,6 +90,16 @@ func IndexBlockEvents(db *gorm.DB, dryRun bool, blockHeight int64, blockTime tim
 	return nil
 }
 
+func UpdateEpochIndexingStatus(db *gorm.DB, dryRun bool, epochNumber uint, epochIdentifier string, dbChainID string, dbChainName string) error {
+	epochToUpdate := Epoch{
+		EpochNumber: epochNumber,
+		Chain:       Chain{ChainID: dbChainID, Name: dbChainName},
+		Identifier:  epochIdentifier,
+	}
+
+	return db.Model(&Epoch{}).Where(&epochToUpdate).Update("indexed", true).Error
+}
+
 func createTaxableEvents(db *gorm.DB, events []TaxableEvent) error {
 	// Ordering matters due to foreign key constraints. Call Create() first to get right foreign key ID
 	return db.Transaction(func(dbTransaction *gorm.DB) error {

--- a/db/models.go
+++ b/db/models.go
@@ -193,4 +193,5 @@ type Epoch struct {
 	StartHeight  uint   `gorm:"uniqueIndex:chainepochidentifierheight"`
 	Identifier   string `gorm:"uniqueIndex:chainepochidentifierheight"`
 	EpochNumber  uint
+	Indexed      bool `gorm:"default:false"`
 }


### PR DESCRIPTION
This PR adds a few new features to epochs:

1. A new flag on the Epoch model for tracking `indexed` values (set to a boolean of default false)
2. Updating the epoch indexer to:
    * Run the epoch updater before indexing to find the newest epochs
    * Updated where clause when gathering epochs to index
        * Sorted by epoch number
        * Only ones that have indexed = false
    * The ability to set the End Epoch config value to -1 to find all epochs past the start config value
    * Setting indexed = true when the epoch is fully indexed 