### PR TITLE
Patch/480 poolmanager errors and 481 remove fatal throws

### DIFF
--- a/core/tx.go
+++ b/core/tx.go
@@ -428,7 +428,8 @@ func ProcessTx(db *gorm.DB, tx txtypes.MergedTx) (txDBWapper dbTypes.TxDBWrapper
 					config.Log.Error(fmt.Sprintf("[Block: %v] ParseCosmosMessage failed for msg of type '%v'.", tx.TxResponse.Height, msgType), err)
 					config.Log.Error(fmt.Sprint(messageLog))
 					config.Log.Error(tx.TxResponse.TxHash)
-					config.Log.Fatal("Issue parsing a cosmos msg that we DO have a parser for! PLEASE INVESTIGATE")
+					config.Log.Error("Issue parsing a cosmos msg that we DO have a parser for! PLEASE INVESTIGATE")
+					return txDBWapper, txTime, fmt.Errorf("error parsing message we have a parser for: '%v'", msgType)
 				}
 				// if this msg isn't include in our list of those we are explicitly ignoring, do something about it.
 				// we have decided to throw the error back up the call stack, which will prevent any indexing from happening on this block and add this to the failed block table

--- a/osmosis/modules/poolmanager/types.go
+++ b/osmosis/modules/poolmanager/types.go
@@ -127,7 +127,6 @@ func (sf *WrapperMsgSwapExactAmountIn) HandleMsg(msgType string, msg sdk.Msg, lo
 		return nil
 	case transferEvt != nil:
 		transferEvts, err := txModule.ParseTransferEvent(*transferEvt)
-
 		if err != nil {
 			return err
 		}
@@ -140,7 +139,6 @@ func (sf *WrapperMsgSwapExactAmountIn) HandleMsg(msgType string, msg sdk.Msg, lo
 		}
 
 		tokenOut, err := sdk.ParseCoinNormalized(lastTransferEvt.Amount)
-
 		if err != nil {
 			return err
 		}

--- a/osmosis/modules/poolmanager/types.go
+++ b/osmosis/modules/poolmanager/types.go
@@ -1,6 +1,7 @@
 package poolmanager
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 
@@ -95,31 +96,70 @@ func (sf *WrapperMsgSwapExactAmountIn) HandleMsg(msgType string, msg sdk.Msg, lo
 
 	// The attribute in the log message that shows you the tokens swapped
 	tokensSwappedEvt := txModule.GetEventWithType("token_swapped", log)
-	if tokensSwappedEvt == nil {
-		return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
+	transferEvt := txModule.GetEventWithType("transfer", log)
+
+	switch {
+	case tokensSwappedEvt != nil:
+		if tokensSwappedEvt == nil {
+			return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
+		}
+
+		// The last route in the hops gives the token out denom and pool ID for the final output
+		lastRoute := sf.OsmosisMsgSwapExactAmountIn.Routes[len(sf.OsmosisMsgSwapExactAmountIn.Routes)-1]
+		lastRouteDenom := lastRoute.TokenOutDenom
+		lastRoutePoolID := lastRoute.PoolId
+
+		tokenOutStr := txModule.GetLastValueForAttribute("tokens_out", tokensSwappedEvt)
+		tokenOutPoolID := txModule.GetLastValueForAttribute("pool_id", tokensSwappedEvt)
+
+		tokenOut, err := sdk.ParseCoinNormalized(tokenOutStr)
+		if err != nil {
+			return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
+		}
+
+		// Sanity check last route swap
+		if tokenOut.Denom != lastRouteDenom || strconv.FormatUint(lastRoutePoolID, 10) != tokenOutPoolID {
+			return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
+		}
+
+		sf.TokenOut = tokenOut
+
+		return nil
+	case transferEvt != nil:
+		transferEvts, err := txModule.ParseTransferEvent(*transferEvt)
+
+		if err != nil {
+			return err
+		}
+
+		// The last transfer event should contain the final transfer to the sender
+		lastTransferEvt := transferEvts[len(transferEvts)-1]
+
+		if lastTransferEvt.Recipient != sf.Address {
+			return errors.New("transfer event recipient does not match message sender")
+		}
+
+		tokenOut, err := sdk.ParseCoinNormalized(lastTransferEvt.Amount)
+
+		if err != nil {
+			return err
+		}
+
+		// The last route in the hops gives the token out denom and pool ID for the final output
+		lastRoute := sf.OsmosisMsgSwapExactAmountIn.Routes[len(sf.OsmosisMsgSwapExactAmountIn.Routes)-1]
+		lastRouteDenom := lastRoute.TokenOutDenom
+
+		if tokenOut.Denom != lastRouteDenom {
+			return errors.New("final transfer denom does not match last route denom")
+		}
+
+		sf.TokenOut = tokenOut
+
+		return nil
+
+	default:
+		return errors.New("no processable events for poolmanager MsgSwapExactAmountIn")
 	}
-
-	// The last route in the hops gives the token out denom and pool ID for the final output
-	lastRoute := sf.OsmosisMsgSwapExactAmountIn.Routes[len(sf.OsmosisMsgSwapExactAmountIn.Routes)-1]
-	lastRouteDenom := lastRoute.TokenOutDenom
-	lastRoutePoolID := lastRoute.PoolId
-
-	tokenOutStr := txModule.GetLastValueForAttribute("tokens_out", tokensSwappedEvt)
-	tokenOutPoolID := txModule.GetLastValueForAttribute("pool_id", tokensSwappedEvt)
-
-	tokenOut, err := sdk.ParseCoinNormalized(tokenOutStr)
-	if err != nil {
-		return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
-	}
-
-	// Sanity check last route swap
-	if tokenOut.Denom != lastRouteDenom || strconv.FormatUint(lastRoutePoolID, 10) != tokenOutPoolID {
-		return &txModule.MessageLogFormatError{MessageType: msgType, Log: fmt.Sprintf("%+v", log)}
-	}
-
-	sf.TokenOut = tokenOut
-
-	return err
 }
 
 // This code is currently untested since I cannot find a TX execution for this


### PR DESCRIPTION
This PR adds the following:

1. Removal of FTL errors when a parser fails -> We are preferring to keep the indexer running and to add to failed blocks table instead
2. A fix for a broken set of poolmanager swaps -> If the token_swapped event is not found, try to parse the transfer event instead.

For (2), poolmanager manages a number of different swap types from a set of modules (Concentrated Liquidity, GAMM). It acts as a common wrapper around these. Osmosis added a new message type that uses WASM for swaps. This new update provides a different set of events.

See these 2 TX for some examples:

1. Block 11509934: https://www.mintscan.io/osmosis/transactions/190EA05714BE7AF6CB6A95519D3CA81E7770A0B8A0E9091464CF1DA0F3E0006F
2. Block 11509978: https://www.mintscan.io/osmosis/transactions/6F0DBD6061FED5D1A6027B6C41A3652797ACD5BDB893DC7D3E35CA22F2B3423D

Closes #480 
Closes #481 