### PR TITLE
Block Enqueue race condition while waiting for latest block to be written

### DIFF
--- a/cmd/block_enqueue.go
+++ b/cmd/block_enqueue.go
@@ -171,7 +171,7 @@ func (idxr *Indexer) enqueueBlocksToProcess(blockChan chan int64, chainID uint) 
 			}
 
 			// Already at the latest block, wait for the next block to be available.
-			for currBlock <= latestBlock && (currBlock <= lastBlock || lastBlock == -1) && len(blockChan) != cap(blockChan) {
+			for currBlock < latestBlock && (currBlock <= lastBlock || lastBlock == -1) && len(blockChan) != cap(blockChan) {
 				// if we are not re-indexing, skip curr block if already indexed
 				if !idxr.cfg.Base.ReIndex && blockAlreadyIndexed(currBlock, chainID, idxr.db) {
 					currBlock++


### PR DESCRIPTION
Force block enqueue to fully wait for block to be available by moving to `< latestBlock` check.

## #487 RCA:

I was able to reproduce the issue from #487 in the following manner:

1. Setup a local node using Osmosis' [LocalOsmosis](https://github.com/osmosis-labs/osmosis/tree/e8b9c10574633368d9ff7378c414b45c450c5d3e/tests/localosmosis#localosmosis) localnet Docker setup
2. Use the following configs (which define a really fast set of RPC workers):
    * `start-block = 1`
    * `end-block = -1`
    * `wait-for-chain = false`
    * `throttling = 0`
    * `rpc-workers = 4`
3. Let the local indexer catch up to the LatestHeight

I was able to reliably reproduce the state height loading error:

![image](https://github.com/DefiantLabs/cosmos-indexer/assets/24580777/e7d5d490-51b3-47b1-8a1d-df7668d33abe)

I think this is happening for the following reason: The Node is reporting LatestHeight from the Status RPC request before the height is fully available at the GetTxsEvent. This leads fast indexer configs to catch up to the chain really quickly and then requesting the Txs at the latest height way too fast.

## This solution

This solution forces the block_enqueue to stay 1 block behind the value reported by latest height. This will prevent ever requesting transactions at a block height that is unavailable.

Closes #487 