### PR TITLE
Update accointing parser to remove self-transfer ignore line

### DIFF
--- a/csv/accounting_test.go
+++ b/csv/accounting_test.go
@@ -54,7 +54,7 @@ func TestAccointingIbcMsgTransferSelf(t *testing.T) {
 		cols := row.GetRowForCsv()
 		// transfer message should be a 'withdraw' from the sender's perspective
 		assert.Equal(t, "withdraw", cols[0], "transaction type should be a withdrawal")
-		assert.Equal(t, "ignored", cols[8], "transaction should not have a classification")
+		assert.Equal(t, "", cols[8], "transaction should not have a classification")
 	}
 }
 

--- a/csv/parsers/accointing/accointing.go
+++ b/csv/parsers/accointing/accointing.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/DefiantLabs/cosmos-tax-cli/config"
-	"github.com/DefiantLabs/cosmos-tax-cli/core"
 	"github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules/bank"
 	"github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules/distribution"
 	"github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules/gov"
@@ -370,19 +369,6 @@ func ParseMsgSwapExactAmountOut(event db.TaxableTransaction) (Row, error) {
 func ParseMsgTransfer(address string, event db.TaxableTransaction) (Row, error) {
 	row := &Row{}
 	err := row.ParseBasic(address, event)
-	selfTransfer := false
-
-	senderAddrPrefix := core.GetAddressPrefix(event.SenderAddress.Address)
-	receiverAddrPrefix := core.GetAddressPrefix(event.ReceiverAddress.Address)
-	if senderAddrPrefix != "" && receiverAddrPrefix != "" {
-		selfTransfer = core.IsAddressEqual(event.SenderAddress.Address, senderAddrPrefix, event.ReceiverAddress.Address, receiverAddrPrefix)
-	}
-
-	// The base bech32 address was the same, so this was a self transfer and is not taxable
-	if selfTransfer {
-		row.Classification = Ignored
-	}
-
 	if err != nil {
 		config.Log.Error("Error with ParseMsgTransfer.", err)
 	}


### PR DESCRIPTION
Accointing was the only one using the self-transfer code, I checked all the other parsers and they do not make any similar checks to cause the external software to ignore these types of entries.

Closes #506 