### PR TITLE
Add TX to fee. Parse fees that were not found through event parsing

### DIFF
--- a/csv/accounting_test.go
+++ b/csv/accounting_test.go
@@ -38,9 +38,10 @@ func TestAccointingIbcMsgTransferSelf(t *testing.T) {
 
 	// make transactions for this user entering and leaving LPs
 	transferTxs := getTestIbcTransferTXs(t, sourceAddress, destAddress, sourceChain, targetChain)
+	emptyFees := []db.Fee{}
 
 	// attempt to parse
-	err := parser.ProcessTaxableTx(sourceAddress.Address, transferTxs)
+	err := parser.ProcessTaxableTx(sourceAddress.Address, transferTxs, emptyFees)
 	assert.Nil(t, err, "should not get error from parsing these transactions")
 
 	// validate output
@@ -83,9 +84,10 @@ func TestAccointingIbcMsgTransferExternal(t *testing.T) {
 
 	// make transactions for this user entering and leaving LPs
 	transferTxs := getTestIbcTransferTXs(t, sourceAddress, destAddress, sourceChain, targetChain)
+	emptyFees := []db.Fee{}
 
 	// attempt to parse
-	err := parser.ProcessTaxableTx(sourceAddress.Address, transferTxs)
+	err := parser.ProcessTaxableTx(sourceAddress.Address, transferTxs, emptyFees)
 	assert.Nil(t, err, "should not get error from parsing these transactions")
 
 	// validate output
@@ -115,9 +117,10 @@ func TestAccointingOsmoLPParsing(t *testing.T) {
 
 	// make transactions for this user entering and leaving LPs
 	transferTxs := getTestSwapTXs(t, targetAddress, chain)
+	emptyFees := []db.Fee{}
 
 	// attempt to parse
-	err := parser.ProcessTaxableTx(targetAddress.Address, transferTxs)
+	err := parser.ProcessTaxableTx(targetAddress.Address, transferTxs, emptyFees)
 	assert.Nil(t, err, "should not get error from parsing these transactions")
 
 	// validate output

--- a/csv/koinly_test.go
+++ b/csv/koinly_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/DefiantLabs/cosmos-tax-cli/config"
 	"github.com/DefiantLabs/cosmos-tax-cli/csv/parsers/koinly"
+	"github.com/DefiantLabs/cosmos-tax-cli/db"
 	"github.com/DefiantLabs/cosmos-tax-cli/osmosis"
 	"github.com/stretchr/testify/assert"
 )
@@ -23,9 +24,10 @@ func TestKoinlyOsmoLPParsing(t *testing.T) {
 
 	// make transactions for this user entering and leaving LPs
 	transferTxs := getTestSwapTXs(t, targetAddress, chain)
+	emptyFees := []db.Fee{}
 
 	// attempt to parse
-	err := parser.ProcessTaxableTx(targetAddress.Address, transferTxs)
+	err := parser.ProcessTaxableTx(targetAddress.Address, transferTxs, emptyFees)
 	assert.Nil(t, err, "should not get error from parsing these transactions")
 
 	// validate output

--- a/csv/parser.go
+++ b/csv/parser.go
@@ -62,7 +62,15 @@ func ParseForAddress(addresses []string, startDate, endDate *time.Time, pgSQL *g
 			return nil, nil, err
 		}
 
-		err = parser.ProcessTaxableTx(address, taxableTxs)
+		// Some TXs may have fees while the address had no taxable TXs
+		// We gather all fees and pass them to the parser
+		taxableFees, err := db.GetTaxableFees(address, pgSQL)
+		if err != nil {
+			config.Log.Error("Error getting taxable fees.", err)
+			return nil, nil, err
+		}
+
+		err = parser.ProcessTaxableTx(address, taxableTxs, taxableFees)
 		if err != nil {
 			config.Log.Error("Error processing taxable transaction.", err)
 			return nil, nil, err

--- a/csv/parsers/cointracker/cointracker.go
+++ b/csv/parsers/cointracker/cointracker.go
@@ -20,7 +20,7 @@ func (p *Parser) TimeLayout() string {
 	return TimeLayout
 }
 
-func (p *Parser) ProcessTaxableTx(address string, taxableTxs []db.TaxableTransaction) error {
+func (p *Parser) ProcessTaxableTx(address string, taxableTxs []db.TaxableTransaction, taxableFees []db.Fee) error {
 	// Build a map, so we know which TX go with which messages
 	txMap := parsers.MakeTXMap(taxableTxs)
 
@@ -54,7 +54,7 @@ func (p *Parser) ProcessTaxableTx(address string, taxableTxs []db.TaxableTransac
 	// Handle fees on all taxableTxs at once, we don't do this in the regular parser or in the parsing groups
 	// This requires HandleFees to process the fees into unique mappings of tx -> fees (since we gather Taxable Messages in the taxableTxs)
 	// If we move it into the ParseTx function or into the ParseGroup function, we may be able to reduce the logic in the HandleFees func
-	feeRows, err := HandleFees(address, taxableTxs)
+	feeRows, err := HandleFees(address, taxableTxs, taxableFees)
 	if err != nil {
 		return err
 	}
@@ -161,9 +161,9 @@ func (p Parser) GetHeaders() []string {
 // If the transaction lists the same amount of fees as there are rows in the CSV,
 // then we spread the fees out one per row. Otherwise we add a line for the fees,
 // where each fee has a separate line.
-func HandleFees(address string, events []db.TaxableTransaction) (rows []Row, err error) {
+func HandleFees(address string, events []db.TaxableTransaction, allFees []db.Fee) (rows []Row, err error) {
 	// No events -- This address didn't pay any fees
-	if len(events) == 0 {
+	if len(events) == 0 && len(allFees) == 0 {
 		return rows, nil
 	}
 
@@ -176,6 +176,15 @@ func HandleFees(address string, events []db.TaxableTransaction) (rows []Row, err
 		feeStore := event.Message.Tx.Fees
 		txToFeesMap[txID] = feeStore
 		txIdsToTx[txID] = event.Message.Tx
+	}
+
+	// Due to the way we are parsing, we may have fees for TX that we don't have events for
+	for _, fee := range allFees {
+		txID := fee.Tx.ID
+		if _, ok := txToFeesMap[txID]; !ok {
+			txToFeesMap[txID] = []db.Fee{fee}
+			txIdsToTx[txID] = fee.Tx
+		}
 	}
 
 	for id, txFees := range txToFeesMap {

--- a/csv/parsers/cryptotaxcalculator/rows.go
+++ b/csv/parsers/cryptotaxcalculator/rows.go
@@ -87,6 +87,22 @@ func (row *Row) ParseBasic(address string, event db.TaxableTransaction) error {
 	return nil
 }
 
+func (row *Row) ParseFee(address string, fee db.Fee) error {
+	row.Date = fee.Tx.Block.TimeStamp
+	row.ID = fee.Tx.Hash
+	row.Type = Fee
+
+	sentConversionAmount, sentConversionSymbol, err := db.ConvertUnits(util.FromNumeric(fee.Amount), fee.Denomination)
+	if err != nil {
+		return fmt.Errorf("cannot parse denom units for TX %s (classification: swap sent)", row.ID)
+	}
+
+	row.BaseAmount = sentConversionAmount.Text('f', -1)
+	row.BaseCurrency = sentConversionSymbol
+
+	return nil
+}
+
 func (row *Row) ParseSwap(event db.TaxableTransaction, address, eventType string) error {
 	row.Date = event.Message.Tx.Block.TimeStamp
 	row.ID = event.Message.Tx.Hash

--- a/csv/parsers/cryptotaxcalculator/types.go
+++ b/csv/parsers/cryptotaxcalculator/types.go
@@ -44,4 +44,5 @@ const (
 	FlatWithdrawal = "flat-withdrawal"
 	Receive        = "receive"
 	Sell           = "sell"
+	Fee            = "fee"
 )

--- a/csv/parsers/koinly/koinly.go
+++ b/csv/parsers/koinly/koinly.go
@@ -46,7 +46,7 @@ func (p *Parser) TimeLayout() string {
 	return TimeLayout
 }
 
-func (p *Parser) ProcessTaxableTx(address string, taxableTxs []db.TaxableTransaction) error {
+func (p *Parser) ProcessTaxableTx(address string, taxableTxs []db.TaxableTransaction, taxableFees []db.Fee) error {
 	// Build a map, so we know which TX go with which messages
 	txMap := parsers.MakeTXMap(taxableTxs)
 
@@ -80,7 +80,7 @@ func (p *Parser) ProcessTaxableTx(address string, taxableTxs []db.TaxableTransac
 	// Handle fees on all taxableTxs at once, we don't do this in the regular parser or in the parsing groups
 	// This requires HandleFees to process the fees into unique mappings of tx -> fees (since we gather Taxable Messages in the taxableTxs)
 	// If we move it into the ParseTx function or into the ParseGroup function, we may be able to reduce the logic in the HandleFees func
-	feeRows, err := HandleFees(address, taxableTxs)
+	feeRows, err := HandleFees(address, taxableTxs, taxableFees)
 	if err != nil {
 		return err
 	}
@@ -235,9 +235,9 @@ func (p Parser) GetHeaders() []string {
 // If the transaction lists the same amount of fees as there are rows in the CSV,
 // then we spread the fees out one per row. Otherwise we add a line for the fees,
 // where each fee has a separate line.
-func HandleFees(address string, events []db.TaxableTransaction) (rows []Row, err error) {
+func HandleFees(address string, events []db.TaxableTransaction, allFees []db.Fee) (rows []Row, err error) {
 	// No events -- This address didn't pay any fees
-	if len(events) == 0 {
+	if len(events) == 0 && len(allFees) == 0 {
 		return rows, nil
 	}
 
@@ -250,6 +250,15 @@ func HandleFees(address string, events []db.TaxableTransaction) (rows []Row, err
 		feeStore := event.Message.Tx.Fees
 		txToFeesMap[txID] = feeStore
 		txIdsToTx[txID] = event.Message.Tx
+	}
+
+	// Due to the way we are parsing, we may have fees for TX that we don't have events for
+	for _, fee := range allFees {
+		txID := fee.Tx.ID
+		if _, ok := txToFeesMap[txID]; !ok {
+			txToFeesMap[txID] = []db.Fee{fee}
+			txIdsToTx[txID] = fee.Tx
+		}
 	}
 
 	for id, txFees := range txToFeesMap {

--- a/csv/parsers/taxbit/taxbit.go
+++ b/csv/parsers/taxbit/taxbit.go
@@ -20,7 +20,7 @@ func (p *Parser) TimeLayout() string {
 	return TimeLayout
 }
 
-func (p *Parser) ProcessTaxableTx(address string, taxableTxs []db.TaxableTransaction) error {
+func (p *Parser) ProcessTaxableTx(address string, taxableTxs []db.TaxableTransaction, taxableFees []db.Fee) error {
 	// Build a map, so we know which TX go with which messages
 	txMap := parsers.MakeTXMap(taxableTxs)
 
@@ -54,7 +54,7 @@ func (p *Parser) ProcessTaxableTx(address string, taxableTxs []db.TaxableTransac
 	// Handle fees on all taxableTxs at once, we don't do this in the regular parser or in the parsing groups
 	// This requires HandleFees to process the fees into unique mappings of tx -> fees (since we gather Taxable Messages in the taxableTxs)
 	// If we move it into the ParseTx function or into the ParseGroup function, we may be able to reduce the logic in the HandleFees func
-	feeRows, err := HandleFees(address, taxableTxs)
+	feeRows, err := HandleFees(address, taxableTxs, taxableFees)
 	if err != nil {
 		return err
 	}
@@ -165,9 +165,9 @@ func (p Parser) GetHeaders() []string {
 // If the transaction lists the same amount of fees as there are rows in the CSV,
 // then we spread the fees out one per row. Otherwise we add a line for the fees,
 // where each fee has a separate line.
-func HandleFees(address string, events []db.TaxableTransaction) (rows []Row, err error) {
+func HandleFees(address string, events []db.TaxableTransaction, allFees []db.Fee) (rows []Row, err error) {
 	// No events -- This address didn't pay any fees
-	if len(events) == 0 {
+	if len(events) == 0 && len(allFees) == 0 {
 		return rows, nil
 	}
 
@@ -180,6 +180,15 @@ func HandleFees(address string, events []db.TaxableTransaction) (rows []Row, err
 		feeStore := event.Message.Tx.Fees
 		txToFeesMap[txID] = feeStore
 		txIdsToTx[txID] = event.Message.Tx
+	}
+
+	// Due to the way we are parsing, we may have fees for TX that we don't have events for
+	for _, fee := range allFees {
+		txID := fee.Tx.ID
+		if _, ok := txToFeesMap[txID]; !ok {
+			txToFeesMap[txID] = []db.Fee{fee}
+			txIdsToTx[txID] = fee.Tx
+		}
 	}
 
 	for id, txFees := range txToFeesMap {

--- a/csv/parsers/types.go
+++ b/csv/parsers/types.go
@@ -8,7 +8,7 @@ import (
 
 type Parser interface {
 	InitializeParsingGroups()
-	ProcessTaxableTx(address string, taxableTxs []db.TaxableTransaction) error
+	ProcessTaxableTx(address string, taxableTxs []db.TaxableTransaction, taxableFees []db.Fee) error
 	ProcessTaxableEvent(taxableEvents []db.TaxableEvent) error
 	GetHeaders() []string
 	GetRows(address string, startDate, endDate *time.Time) ([]CsvRow, error)

--- a/db/models.go
+++ b/db/models.go
@@ -49,6 +49,7 @@ type Tx struct {
 type Fee struct {
 	ID             uint            `gorm:"primaryKey"`
 	TxID           uint            `gorm:"uniqueIndex:txDenomFee"`
+	Tx             Tx              `gorm:"foreignKey:tx_id"`
 	Amount         decimal.Decimal `gorm:"type:decimal(78,0);"`
 	DenominationID uint            `gorm:"uniqueIndex:txDenomFee"`
 	Denomination   Denom           `gorm:"foreignKey:DenominationID"`

--- a/db/search.go
+++ b/db/search.go
@@ -20,6 +20,13 @@ func GetTaxableTransactions(address string, db *gorm.DB) ([]TaxableTransaction, 
 	return taxableTransactions, result.Error
 }
 
+func GetTaxableFees(address string, db *gorm.DB) ([]Fee, error) {
+	var fees []Fee
+	result := db.Joins("JOIN addresses ON addresses.id = fees.payer_address_id").
+		Where("addresses.address = ?", address).Preload("PayerAddress").Preload("Denomination").Preload("Tx").Find(&fees)
+	return fees, result.Error
+}
+
 func GetTaxableEvents(address string, db *gorm.DB) ([]TaxableEvent, error) {
 	// Look up all TaxableEvents for the addresses
 	var taxableEvents []TaxableEvent


### PR DESCRIPTION
Gathers fees that were not included in a taxable tx in all CSV parsers. Fixes a bug where fees were missing if the address did not actually participate in the sends/receives of the messages (such as a relayer relaying IBC messages for addresses).

Closes #512 