### PR TITLE
Update gov module support to work with both v1beta1 and v1 message types

### DIFF
--- a/core/tx.go
+++ b/core/tx.go
@@ -48,6 +48,8 @@ var messageTypeHandler = map[string][]func() txtypes.CosmosMessage{
 	distribution.MsgFundCommunityPool:           {func() txtypes.CosmosMessage { return &distribution.WrapperMsgFundCommunityPool{} }},
 	gov.MsgDeposit:                              {func() txtypes.CosmosMessage { return &gov.WrapperMsgDeposit{} }},
 	gov.MsgSubmitProposal:                       {func() txtypes.CosmosMessage { return &gov.WrapperMsgSubmitProposal{} }},
+	gov.MsgDepositV1:                            {func() txtypes.CosmosMessage { return &gov.WrapperMsgDepositV1{} }},
+	gov.MsgSubmitProposalV1:                     {func() txtypes.CosmosMessage { return &gov.WrapperMsgSubmitProposalV1{} }},
 	staking.MsgDelegate:                         {func() txtypes.CosmosMessage { return &staking.WrapperMsgDelegate{} }},
 	staking.MsgUndelegate:                       {func() txtypes.CosmosMessage { return &staking.WrapperMsgUndelegate{} }},
 	staking.MsgBeginRedelegate:                  {func() txtypes.CosmosMessage { return &staking.WrapperMsgBeginRedelegate{} }},
@@ -70,8 +72,10 @@ var messageTypeIgnorer = map[string]interface{}{
 	// Making a stableswap config change is not taxable
 	gamm.MsgStableSwapAdjustScalingFactors: nil,
 	// Voting is not taxable
-	gov.MsgVote:         nil,
-	gov.MsgVoteWeighted: nil,
+	gov.MsgVote:           nil,
+	gov.MsgVoteWeighted:   nil,
+	gov.MsgVoteV1:         nil,
+	gov.MsgVoteWeightedV1: nil,
 	// The IBC msgs below do not create taxable events
 	ibc.MsgTransfer:              nil,
 	ibc.MsgUpdateClient:          nil,

--- a/cosmos/modules/gov/types.go
+++ b/cosmos/modules/gov/types.go
@@ -9,14 +9,19 @@ import (
 	"github.com/DefiantLabs/cosmos-tax-cli/util"
 	stdTypes "github.com/cosmos/cosmos-sdk/types"
 	bankTypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	govTypesV1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	govTypes "github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
 )
 
 const (
-	MsgVote           = "/cosmos.gov.v1beta1.MsgVote"
-	MsgDeposit        = "/cosmos.gov.v1beta1.MsgDeposit"        // handle additional deposits to the given proposal
-	MsgSubmitProposal = "/cosmos.gov.v1beta1.MsgSubmitProposal" // handle the initial deposit for the proposer
-	MsgVoteWeighted   = "/cosmos.gov.v1beta1.MsgVoteWeighted"
+	MsgVote             = "/cosmos.gov.v1beta1.MsgVote"
+	MsgDeposit          = "/cosmos.gov.v1beta1.MsgDeposit"        // handle additional deposits to the given proposal
+	MsgSubmitProposal   = "/cosmos.gov.v1beta1.MsgSubmitProposal" // handle the initial deposit for the proposer
+	MsgVoteWeighted     = "/cosmos.gov.v1beta1.MsgVoteWeighted"
+	MsgVoteV1           = "/cosmos.gov.v1.MsgVote"
+	MsgDepositV1        = "/cosmos.gov.v1.MsgDeposit"        // handle additional deposits to the given proposal
+	MsgSubmitProposalV1 = "/cosmos.gov.v1.MsgSubmitProposal" // handle the initial deposit for the proposer
+	MsgVoteWeightedV1   = "/cosmos.gov.v1.MsgVoteWeighted"
 )
 
 type WrapperMsgSubmitProposal struct {
@@ -30,6 +35,22 @@ type WrapperMsgSubmitProposal struct {
 type WrapperMsgDeposit struct {
 	txModule.Message
 	CosmosMsgDeposit       *govTypes.MsgDeposit
+	CoinReceived           stdTypes.Coin
+	MultiCoinsReceived     stdTypes.Coins
+	DepositReceiverAddress string
+}
+
+type WrapperMsgSubmitProposalV1 struct {
+	txModule.Message
+	CosmosMsgSubmitProposal *govTypesV1.MsgSubmitProposal
+	CoinReceived            stdTypes.Coin
+	MultiCoinsReceived      stdTypes.Coins
+	DepositReceiverAddress  string
+}
+
+type WrapperMsgDepositV1 struct {
+	txModule.Message
+	CosmosMsgDeposit       *govTypesV1.MsgDeposit
 	CoinReceived           stdTypes.Coin
 	MultiCoinsReceived     stdTypes.Coins
 	DepositReceiverAddress string
@@ -58,6 +79,50 @@ func (sf *WrapperMsgSubmitProposal) ParseRelevantData() []parsingTypes.MessageRe
 }
 
 func (sf *WrapperMsgDeposit) ParseRelevantData() []parsingTypes.MessageRelevantInformation {
+	relevantData := make([]parsingTypes.MessageRelevantInformation, len(sf.CosmosMsgDeposit.Amount))
+
+	for i, v := range sf.CosmosMsgDeposit.Amount {
+		var currRelevantData parsingTypes.MessageRelevantInformation
+		currRelevantData.SenderAddress = sf.CosmosMsgDeposit.Depositor
+		currRelevantData.ReceiverAddress = sf.DepositReceiverAddress
+
+		// Amount always seems to be an integer, float may be an extra unneeded step
+		currRelevantData.AmountSent = v.Amount.BigInt()
+		currRelevantData.DenominationSent = v.Denom
+
+		// This is required since we do CSV parsing on the receiver here too
+		currRelevantData.AmountReceived = v.Amount.BigInt()
+		currRelevantData.DenominationReceived = v.Denom
+
+		relevantData[i] = currRelevantData
+	}
+
+	return relevantData
+}
+
+func (sf *WrapperMsgSubmitProposalV1) ParseRelevantData() []parsingTypes.MessageRelevantInformation {
+	relevantData := make([]parsingTypes.MessageRelevantInformation, len(sf.CosmosMsgSubmitProposal.InitialDeposit))
+
+	for i, v := range sf.CosmosMsgSubmitProposal.InitialDeposit {
+		var currRelevantData parsingTypes.MessageRelevantInformation
+		currRelevantData.SenderAddress = sf.CosmosMsgSubmitProposal.Proposer
+		currRelevantData.ReceiverAddress = sf.DepositReceiverAddress
+
+		// Amount always seems to be an integer, float may be an extra unneeded step
+		currRelevantData.AmountSent = v.Amount.BigInt()
+		currRelevantData.DenominationSent = v.Denom
+
+		// This is required since we do CSV parsing on the receiver here too
+		currRelevantData.AmountReceived = v.Amount.BigInt()
+		currRelevantData.DenominationReceived = v.Denom
+
+		relevantData[i] = currRelevantData
+	}
+
+	return relevantData
+}
+
+func (sf *WrapperMsgDepositV1) ParseRelevantData() []parsingTypes.MessageRelevantInformation {
 	relevantData := make([]parsingTypes.MessageRelevantInformation, len(sf.CosmosMsgDeposit.Amount))
 
 	for i, v := range sf.CosmosMsgDeposit.Amount {
@@ -171,12 +236,114 @@ func (sf *WrapperMsgDeposit) HandleMsg(msgType string, msg stdTypes.Msg, log *tx
 	return err
 }
 
+// Proposal with an initial deposit
+func (sf *WrapperMsgSubmitProposalV1) HandleMsg(msgType string, msg stdTypes.Msg, log *txModule.LogMessage) error {
+	sf.Type = msgType
+	sf.CosmosMsgSubmitProposal = msg.(*govTypesV1.MsgSubmitProposal)
+
+	// Confirm that the action listed in the message log matches the Message type
+	validLog := txModule.IsMessageActionEquals(sf.GetType(), log)
+	if !validLog {
+		return util.ReturnInvalidLog(msgType, log)
+	}
+
+	// If there was an initial deposit, there will be a transfer log with sender and amount
+	proposerDepositedCoinsEvt := txModule.GetEventWithType(bankTypes.EventTypeTransfer, log)
+	if proposerDepositedCoinsEvt == nil {
+		return nil
+	}
+
+	coinsReceived, err := txModule.GetValueForAttribute("amount", proposerDepositedCoinsEvt)
+	if err != nil {
+		return err
+	}
+
+	recipientAccount, err := txModule.GetValueForAttribute("recipient", proposerDepositedCoinsEvt)
+	if err != nil {
+		return err
+	}
+
+	sf.DepositReceiverAddress = recipientAccount
+
+	// This may be able to be optimized by doing one or the other
+	coin, err := stdTypes.ParseCoinNormalized(coinsReceived)
+	if err != nil {
+		sf.MultiCoinsReceived, err = stdTypes.ParseCoinsNormalized(coinsReceived)
+		if err != nil {
+			config.Log.Error("Error parsing coins normalized", err)
+			return err
+		}
+	} else {
+		sf.CoinReceived = coin
+	}
+
+	return err
+}
+
+// Additional deposit
+func (sf *WrapperMsgDepositV1) HandleMsg(msgType string, msg stdTypes.Msg, log *txModule.LogMessage) error {
+	sf.Type = msgType
+	sf.CosmosMsgDeposit = msg.(*govTypesV1.MsgDeposit)
+
+	// Confirm that the action listed in the message log matches the Message type
+	validLog := txModule.IsMessageActionEquals(sf.GetType(), log)
+	if !validLog {
+		return util.ReturnInvalidLog(msgType, log)
+	}
+
+	// If there was an initial deposit, there will be a transfer log with sender and amount
+	proposerDepositedCoinsEvt := txModule.GetEventWithType(bankTypes.EventTypeTransfer, log)
+	if proposerDepositedCoinsEvt == nil {
+		return nil
+	}
+
+	coinsReceived, err := txModule.GetValueForAttribute("amount", proposerDepositedCoinsEvt)
+	if err != nil {
+		return err
+	}
+
+	// This may be able to be optimized by doing one or the other
+	coin, err := stdTypes.ParseCoinNormalized(coinsReceived)
+	if err != nil {
+		return err
+	}
+
+	recipientAccount, err := txModule.GetValueForAttribute("recipient", proposerDepositedCoinsEvt)
+	if err != nil {
+		return err
+	}
+
+	sf.DepositReceiverAddress = recipientAccount
+
+	if err != nil {
+		sf.MultiCoinsReceived, err = stdTypes.ParseCoinsNormalized(coinsReceived)
+		if err != nil {
+			config.Log.Error("Error parsing coins normalized", err)
+			return err
+		}
+	} else {
+		sf.CoinReceived = coin
+	}
+
+	return err
+}
+
 func (sf *WrapperMsgDeposit) String() string {
-	return fmt.Sprintf("WrapperMsgDeposit: Address %s deposited %s",
+	return fmt.Sprintf("MsgDeposit: Address %s deposited %s",
 		sf.CosmosMsgDeposit.Depositor, sf.CosmosMsgDeposit.Amount)
 }
 
 func (sf *WrapperMsgSubmitProposal) String() string {
-	return fmt.Sprintf("WrapperMsgDeposit: Address %s deposited %s",
+	return fmt.Sprintf("MsgSubmit: Address %s deposited %s",
+		sf.CosmosMsgSubmitProposal.Proposer, sf.CosmosMsgSubmitProposal.InitialDeposit)
+}
+
+func (sf *WrapperMsgDepositV1) String() string {
+	return fmt.Sprintf("MsgDeposit: Address %s deposited %s",
+		sf.CosmosMsgDeposit.Depositor, sf.CosmosMsgDeposit.Amount)
+}
+
+func (sf *WrapperMsgSubmitProposalV1) String() string {
+	return fmt.Sprintf("MsgSubmit: Address %s deposited %s",
 		sf.CosmosMsgSubmitProposal.Proposer, sf.CosmosMsgSubmitProposal.InitialDeposit)
 }

--- a/csv/parsers/accointing/accointing.go
+++ b/csv/parsers/accointing/accointing.go
@@ -258,9 +258,9 @@ func ParseTx(address string, events []db.TaxableTransaction) (rows []parsers.Csv
 			newRow, err = ParseMsgSwapExactAmountIn(event)
 		case gamm.MsgSwapExactAmountOut:
 			newRow, err = ParseMsgSwapExactAmountOut(event)
-		case gov.MsgSubmitProposal:
+		case gov.MsgSubmitProposal, gov.MsgSubmitProposalV1:
 			newRow, err = ParseMsgSubmitProposal(address, event)
-		case gov.MsgDeposit:
+		case gov.MsgDeposit, gov.MsgDepositV1:
 			newRow, err = ParseMsgDeposit(address, event)
 		case ibc.MsgTransfer:
 			newRow, err = ParseMsgTransfer(address, event)

--- a/csv/parsers/cointracker/cointracker.go
+++ b/csv/parsers/cointracker/cointracker.go
@@ -247,9 +247,9 @@ func ParseTx(address string, events []db.TaxableTransaction) (rows []parsers.Csv
 			newRow, err = ParseMsgWithdrawDelegatorReward(address, event)
 		case staking.MsgBeginRedelegate:
 			newRow, err = ParseMsgWithdrawDelegatorReward(address, event)
-		case gov.MsgSubmitProposal:
+		case gov.MsgSubmitProposal, gov.MsgSubmitProposalV1:
 			newRow, err = ParseMsgSubmitProposal(address, event)
-		case gov.MsgDeposit:
+		case gov.MsgDeposit, gov.MsgDepositV1:
 			newRow, err = ParseMsgDeposit(address, event)
 		case gamm.MsgSwapExactAmountIn:
 			newRow, err = ParseMsgSwapExactAmountIn(event)

--- a/csv/parsers/cryptotaxcalculator/cryptotaxcalculator.go
+++ b/csv/parsers/cryptotaxcalculator/cryptotaxcalculator.go
@@ -201,9 +201,9 @@ func ParseTx(address string, events []db.TaxableTransaction) (rows []parsers.Csv
 			newRow, err = ParseMsgSwapExactAmountIn(address, event)
 		case gamm.MsgSwapExactAmountOut:
 			newRow, err = ParseMsgSwapExactAmountOut(address, event)
-		case gov.MsgSubmitProposal:
+		case gov.MsgSubmitProposal, gov.MsgSubmitProposalV1:
 			newRow, err = ParseMsgSubmitProposal(address, event)
-		case gov.MsgDeposit:
+		case gov.MsgDeposit, gov.MsgDepositV1:
 			newRow, err = ParseMsgDeposit(address, event)
 		case ibc.MsgTransfer:
 			newRow, err = ParseMsgTransfer(address, event)

--- a/csv/parsers/koinly/koinly.go
+++ b/csv/parsers/koinly/koinly.go
@@ -327,9 +327,9 @@ func ParseTx(address string, events []db.TaxableTransaction) (rows []parsers.Csv
 			newRow, err = ParseMsgSwapExactAmountOut(event)
 		case ibc.MsgTransfer:
 			newRow, err = ParseMsgTransfer(address, event)
-		case gov.MsgSubmitProposal:
+		case gov.MsgSubmitProposal, gov.MsgSubmitProposalV1:
 			newRow, err = ParseMsgSubmitProposal(address, event)
-		case gov.MsgDeposit:
+		case gov.MsgDeposit, gov.MsgDepositV1:
 			newRow, err = ParseMsgDeposit(address, event)
 		case ibc.MsgAcknowledgement:
 			newRow, err = ParseMsgTransfer(address, event)

--- a/csv/parsers/taxbit/taxbit.go
+++ b/csv/parsers/taxbit/taxbit.go
@@ -251,13 +251,13 @@ func ParseTx(address string, events []db.TaxableTransaction) (rows []parsers.Csv
 			newRow, err = ParseMsgWithdrawDelegatorReward(address, event)
 		case staking.MsgBeginRedelegate:
 			newRow, err = ParseMsgWithdrawDelegatorReward(address, event)
-		case gov.MsgSubmitProposal:
+		case gov.MsgSubmitProposal, gov.MsgSubmitProposalV1:
 			newRow, err = ParseMsgSubmitProposal(address, event)
 		case gamm.MsgSwapExactAmountIn:
 			newRow, err = ParseMsgSwapExactAmountIn(event)
 		case gamm.MsgSwapExactAmountOut:
 			newRow, err = ParseMsgSwapExactAmountOut(event)
-		case gov.MsgDeposit:
+		case gov.MsgDeposit, gov.MsgDepositV1:
 			newRow, err = ParseMsgDeposit(address, event)
 		case ibc.MsgTransfer:
 			newRow, err = ParseMsgTransfer(address, event)


### PR DESCRIPTION
Adds Gov v1 support:

1. Ignores v1 versions of voting just like v1beta1
2. Adds parsers for v1 SubmitProposal and Deposit
3. Adds CSV processing as well