### PR TITLE
Patch/missing parsers concentratedliq other errors

### DIFF
--- a/core/tx.go
+++ b/core/tx.go
@@ -105,8 +105,9 @@ var messageTypeIgnorer = map[string]interface{}{
 	slashing.MsgUnjail:       nil,
 	slashing.MsgUpdateParams: nil,
 	// Creating and editing validator is not taxable
-	staking.MsgCreateValidator: nil,
-	staking.MsgEditValidator:   nil,
+	staking.MsgCreateValidator:           nil,
+	staking.MsgEditValidator:             nil,
+	staking.MsgCancelUnbondingDelegation: nil, // No rewards are withdrawn when cancelling an unbonding delegation
 	// Delegating and Locking are not taxable
 	superfluid.MsgSuperfluidDelegate:                                    nil,
 	superfluid.MsgSuperfluidUndelegate:                                  nil,

--- a/cosmos/modules/staking/types.go
+++ b/cosmos/modules/staking/types.go
@@ -14,11 +14,12 @@ import (
 )
 
 const (
-	MsgDelegate        = "/cosmos.staking.v1beta1.MsgDelegate"
-	MsgUndelegate      = "/cosmos.staking.v1beta1.MsgUndelegate"
-	MsgBeginRedelegate = "/cosmos.staking.v1beta1.MsgBeginRedelegate"
-	MsgCreateValidator = "/cosmos.staking.v1beta1.MsgCreateValidator" // An explicitly ignored msg for tx parsing purposes
-	MsgEditValidator   = "/cosmos.staking.v1beta1.MsgEditValidator"   // An explicitly ignored msg for tx parsing purposes
+	MsgDelegate                  = "/cosmos.staking.v1beta1.MsgDelegate"
+	MsgUndelegate                = "/cosmos.staking.v1beta1.MsgUndelegate"
+	MsgBeginRedelegate           = "/cosmos.staking.v1beta1.MsgBeginRedelegate"
+	MsgCreateValidator           = "/cosmos.staking.v1beta1.MsgCreateValidator" // An explicitly ignored msg for tx parsing purposes
+	MsgEditValidator             = "/cosmos.staking.v1beta1.MsgEditValidator"   // An explicitly ignored msg for tx parsing purposes
+	MsgCancelUnbondingDelegation = "/cosmos.staking.v1beta1.MsgCancelUnbondingDelegation"
 )
 
 type WrapperMsgDelegate struct {

--- a/csv/parsers/accointing/accointing.go
+++ b/csv/parsers/accointing/accointing.go
@@ -13,6 +13,7 @@ import (
 	"github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules/staking"
 	"github.com/DefiantLabs/cosmos-tax-cli/csv/parsers"
 	"github.com/DefiantLabs/cosmos-tax-cli/db"
+	"github.com/DefiantLabs/cosmos-tax-cli/osmosis/modules/concentratedliquidity"
 	"github.com/DefiantLabs/cosmos-tax-cli/osmosis/modules/gamm"
 	"github.com/DefiantLabs/cosmos-tax-cli/osmosis/modules/poolmanager"
 	"github.com/DefiantLabs/cosmos-tax-cli/util"
@@ -250,6 +251,8 @@ func ParseTx(address string, events []db.TaxableTransaction) (rows []parsers.Csv
 			newRow, err = ParseMsgRecvPacket(address, event)
 		case poolmanager.MsgSplitRouteSwapExactAmountIn, poolmanager.MsgSwapExactAmountIn, poolmanager.MsgSwapExactAmountOut:
 			newRow, err = ParsePoolManagerSwap(event)
+		case concentratedliquidity.MsgCollectIncentives, concentratedliquidity.MsgCollectSpreadRewards:
+			newRow, err = ParseConcentratedLiquidityCollection(event)
 		default:
 			config.Log.Errorf("no parser for message type '%v'", event.Message.MessageType.MessageType)
 			continue
@@ -434,5 +437,26 @@ func ParsePoolManagerSwap(event db.TaxableTransaction) (Row, error) {
 	if err != nil {
 		config.Log.Error("Error with ParseMsgSwapExactAmountOut.", err)
 	}
+	return *row, err
+}
+
+func ParseConcentratedLiquidityCollection(event db.TaxableTransaction) (Row, error) {
+	row := &Row{}
+	row.OperationID = event.Message.Tx.Hash
+	row.Classification = LiquidityPool
+	row.Date = event.Message.Tx.Block.TimeStamp.Format(TimeLayout)
+
+	denomToUse := event.DenominationReceived
+	amountToUse := event.AmountReceived
+
+	conversionAmount, conversionSymbol, err := db.ConvertUnits(util.FromNumeric(amountToUse), denomToUse)
+	if err != nil {
+		config.Log.Error("Error with ParseConcentratedLiquidityCollection.", err)
+		return *row, fmt.Errorf("cannot parse denom units for TX %s (classification: deposit)", row.OperationID)
+	}
+
+	row.InBuyAmount = conversionAmount.Text('f', -1)
+	row.InBuyAsset = conversionSymbol
+
 	return *row, err
 }

--- a/csv/parsers/cointracker/cointracker.go
+++ b/csv/parsers/cointracker/cointracker.go
@@ -13,6 +13,7 @@ import (
 	"github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules/staking"
 	"github.com/DefiantLabs/cosmos-tax-cli/csv/parsers"
 	"github.com/DefiantLabs/cosmos-tax-cli/db"
+	"github.com/DefiantLabs/cosmos-tax-cli/osmosis/modules/concentratedliquidity"
 	"github.com/DefiantLabs/cosmos-tax-cli/osmosis/modules/gamm"
 	"github.com/DefiantLabs/cosmos-tax-cli/osmosis/modules/poolmanager"
 	"github.com/DefiantLabs/cosmos-tax-cli/util"
@@ -212,6 +213,8 @@ func ParseTx(address string, events []db.TaxableTransaction, fees []db.Fee) (row
 			newRow, err = ParseMsgRecvPacket(address, event)
 		case poolmanager.MsgSplitRouteSwapExactAmountIn, poolmanager.MsgSwapExactAmountIn, poolmanager.MsgSwapExactAmountOut:
 			newRow, err = ParsePoolManagerSwap(event)
+		case concentratedliquidity.MsgCollectIncentives, concentratedliquidity.MsgCollectSpreadRewards:
+			newRow, err = ParseConcentratedLiquidityCollection(event)
 		default:
 			config.Log.Errorf("no parser for message type '%v'", event.Message.MessageType.MessageType)
 			continue
@@ -420,5 +423,23 @@ func ParseOsmosisReward(event db.TaxableEvent) (Row, error) {
 	if err != nil {
 		config.Log.Error("Error with ParseOsmosisReward.", err)
 	}
+	return *row, err
+}
+
+func ParseConcentratedLiquidityCollection(event db.TaxableTransaction) (Row, error) {
+	row := &Row{}
+	denomToUse := event.DenominationReceived
+	amountToUse := event.AmountReceived
+
+	conversionAmount, conversionSymbol, err := db.ConvertUnits(util.FromNumeric(amountToUse), denomToUse)
+	if err != nil {
+		config.Log.Error("Error with ParseConcentratedLiquidityCollection.", err)
+		return *row, fmt.Errorf("cannot parse denom units for TX %s (classification: deposit)", event.Message.Tx.Hash)
+	}
+
+	row.ReceivedAmount = conversionAmount.Text('f', -1)
+	row.ReceivedCurrency = conversionSymbol
+	row.Date = event.Message.Tx.Block.TimeStamp.Format(TimeLayout)
+
 	return *row, err
 }

--- a/csv/parsers/koinly/koinly.go
+++ b/csv/parsers/koinly/koinly.go
@@ -15,6 +15,7 @@ import (
 	"github.com/DefiantLabs/cosmos-tax-cli/cosmos/modules/staking"
 	"github.com/DefiantLabs/cosmos-tax-cli/csv/parsers"
 	"github.com/DefiantLabs/cosmos-tax-cli/db"
+	"github.com/DefiantLabs/cosmos-tax-cli/osmosis/modules/concentratedliquidity"
 	"github.com/DefiantLabs/cosmos-tax-cli/osmosis/modules/gamm"
 	"github.com/DefiantLabs/cosmos-tax-cli/osmosis/modules/poolmanager"
 	"github.com/DefiantLabs/cosmos-tax-cli/util"
@@ -316,6 +317,8 @@ func ParseTx(address string, events []db.TaxableTransaction) (rows []parsers.Csv
 			newRow, err = ParseMsgRecvPacket(address, event)
 		case poolmanager.MsgSplitRouteSwapExactAmountIn, poolmanager.MsgSwapExactAmountIn, poolmanager.MsgSwapExactAmountOut:
 			newRow, err = ParsePoolManagerSwap(event)
+		case concentratedliquidity.MsgCollectIncentives, concentratedliquidity.MsgCollectSpreadRewards:
+			newRow, err = ParseConcentratedLiquidityCollection(event)
 		default:
 			config.Log.Errorf("no parser for message type '%v'", event.Message.MessageType.MessageType)
 			continue
@@ -501,5 +504,25 @@ func ParsePoolManagerSwap(event db.TaxableTransaction) (Row, error) {
 	if err != nil {
 		config.Log.Error("Error with ParseMsgSwapExactAmountOut.", err)
 	}
+	return *row, err
+}
+
+func ParseConcentratedLiquidityCollection(event db.TaxableTransaction) (Row, error) {
+	row := &Row{}
+	denomToUse := event.DenominationReceived
+	amountToUse := event.AmountReceived
+
+	conversionAmount, conversionSymbol, err := db.ConvertUnits(util.FromNumeric(amountToUse), denomToUse)
+	if err != nil {
+		config.Log.Error("Error with ParseConcentratedLiquidityCollection.", err)
+		return *row, fmt.Errorf("cannot parse denom units for TX %s (classification: deposit)", event.Message.Tx.Hash)
+	}
+
+	row.ReceivedAmount = conversionAmount.Text('f', -1)
+	row.ReceivedCurrency = conversionSymbol
+	row.Label = Income
+	row.Date = event.Message.Tx.Block.TimeStamp.Format(TimeLayout)
+	row.TxHash = event.Message.Tx.Hash
+
 	return *row, err
 }


### PR DESCRIPTION
Fixes the following:

1. Missing CSV parsers for a few concentrated liquidity reward collection messages
2. Missing ignore list entries for staking MsgCancelUnbondingDelegation