### PR TITLE
Patch/csv parsers various message types 2

### DIFF
--- a/csv/parsers/accointing/accointing.go
+++ b/csv/parsers/accointing/accointing.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DefiantLabs/cosmos-tax-cli/osmosis/modules/concentratedliquidity"
 	"github.com/DefiantLabs/cosmos-tax-cli/osmosis/modules/gamm"
 	"github.com/DefiantLabs/cosmos-tax-cli/osmosis/modules/poolmanager"
+	"github.com/DefiantLabs/cosmos-tax-cli/osmosis/modules/valsetpref"
 	"github.com/DefiantLabs/cosmos-tax-cli/util"
 )
 
@@ -253,6 +254,8 @@ func ParseTx(address string, events []db.TaxableTransaction) (rows []parsers.Csv
 			newRow, err = ParsePoolManagerSwap(event)
 		case concentratedliquidity.MsgCollectIncentives, concentratedliquidity.MsgCollectSpreadRewards:
 			newRow, err = ParseConcentratedLiquidityCollection(event)
+		case valsetpref.MsgDelegateBondedTokens, valsetpref.MsgUndelegateFromValidatorSet, valsetpref.MsgRedelegateValidatorSet, valsetpref.MsgWithdrawDelegationRewards, valsetpref.MsgDelegateToValidatorSet, valsetpref.MsgUndelegateFromRebalancedValidatorSet:
+			newRow, err = ParseValsetPrefRewards(event)
 		default:
 			config.Log.Errorf("no parser for message type '%v'", event.Message.MessageType.MessageType)
 			continue
@@ -459,4 +462,19 @@ func ParseConcentratedLiquidityCollection(event db.TaxableTransaction) (Row, err
 	row.InBuyAsset = conversionSymbol
 
 	return *row, err
+}
+
+func ParseValsetPrefRewards(event db.TaxableTransaction) (Row, error) {
+	row := &Row{}
+	row.OperationID = event.Message.Tx.Hash
+	row.TransactionType = Withdraw
+	row.Classification = Staked
+	row.Date = event.Message.Tx.Block.TimeStamp.Format(TimeLayout)
+
+	err := parseAndAddReceivedAmount(row, event)
+	if err != nil {
+		return *row, err
+	}
+
+	return *row, nil
 }

--- a/csv/parsers/accointing/accointing.go
+++ b/csv/parsers/accointing/accointing.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DefiantLabs/cosmos-tax-cli/osmosis/modules/concentratedliquidity"
 	"github.com/DefiantLabs/cosmos-tax-cli/osmosis/modules/gamm"
 	"github.com/DefiantLabs/cosmos-tax-cli/osmosis/modules/poolmanager"
+	"github.com/DefiantLabs/cosmos-tax-cli/osmosis/modules/tokenfactory"
 	"github.com/DefiantLabs/cosmos-tax-cli/osmosis/modules/valsetpref"
 	"github.com/DefiantLabs/cosmos-tax-cli/util"
 )
@@ -256,6 +257,8 @@ func ParseTx(address string, events []db.TaxableTransaction) (rows []parsers.Csv
 			newRow, err = ParseConcentratedLiquidityCollection(event)
 		case valsetpref.MsgDelegateBondedTokens, valsetpref.MsgUndelegateFromValidatorSet, valsetpref.MsgRedelegateValidatorSet, valsetpref.MsgWithdrawDelegationRewards, valsetpref.MsgDelegateToValidatorSet, valsetpref.MsgUndelegateFromRebalancedValidatorSet:
 			newRow, err = ParseValsetPrefRewards(event)
+		case tokenfactory.MsgMint, tokenfactory.MsgBurn:
+			newRow, err = ParseTokenFactoryEvents(address, event)
 		default:
 			config.Log.Errorf("no parser for message type '%v'", event.Message.MessageType.MessageType)
 			continue
@@ -474,6 +477,16 @@ func ParseValsetPrefRewards(event db.TaxableTransaction) (Row, error) {
 	err := parseAndAddReceivedAmount(row, event)
 	if err != nil {
 		return *row, err
+	}
+
+	return *row, nil
+}
+
+func ParseTokenFactoryEvents(address string, event db.TaxableTransaction) (Row, error) {
+	row := &Row{}
+	err := row.ParseBasic(address, event)
+	if err != nil {
+		config.Log.Error("Error with ParseMsgMultiSend.", err)
 	}
 
 	return *row, nil

--- a/csv/parsers/cointracker/cointracker.go
+++ b/csv/parsers/cointracker/cointracker.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DefiantLabs/cosmos-tax-cli/osmosis/modules/concentratedliquidity"
 	"github.com/DefiantLabs/cosmos-tax-cli/osmosis/modules/gamm"
 	"github.com/DefiantLabs/cosmos-tax-cli/osmosis/modules/poolmanager"
+	"github.com/DefiantLabs/cosmos-tax-cli/osmosis/modules/tokenfactory"
 	"github.com/DefiantLabs/cosmos-tax-cli/osmosis/modules/valsetpref"
 	"github.com/DefiantLabs/cosmos-tax-cli/util"
 )
@@ -218,6 +219,8 @@ func ParseTx(address string, events []db.TaxableTransaction, fees []db.Fee) (row
 			newRow, err = ParseConcentratedLiquidityCollection(event)
 		case valsetpref.MsgDelegateBondedTokens, valsetpref.MsgUndelegateFromValidatorSet, valsetpref.MsgRedelegateValidatorSet, valsetpref.MsgWithdrawDelegationRewards, valsetpref.MsgDelegateToValidatorSet, valsetpref.MsgUndelegateFromRebalancedValidatorSet:
 			newRow, err = ParseValsetPrefRewards(event)
+		case tokenfactory.MsgMint, tokenfactory.MsgBurn:
+			newRow, err = ParseTokenFactoryEvents(address, event)
 		default:
 			config.Log.Errorf("no parser for message type '%v'", event.Message.MessageType.MessageType)
 			continue
@@ -454,6 +457,16 @@ func ParseValsetPrefRewards(event db.TaxableTransaction) (Row, error) {
 	err := parseAndAddReceivedAmount(row, event)
 	if err != nil {
 		return *row, err
+	}
+
+	return *row, nil
+}
+
+func ParseTokenFactoryEvents(address string, event db.TaxableTransaction) (Row, error) {
+	row := &Row{}
+	err := row.ParseBasic(address, event)
+	if err != nil {
+		config.Log.Error("Error with ParseMsgMultiSend.", err)
 	}
 
 	return *row, nil

--- a/csv/parsers/cryptotaxcalculator/cryptotaxcalculator.go
+++ b/csv/parsers/cryptotaxcalculator/cryptotaxcalculator.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DefiantLabs/cosmos-tax-cli/osmosis/modules/concentratedliquidity"
 	"github.com/DefiantLabs/cosmos-tax-cli/osmosis/modules/gamm"
 	"github.com/DefiantLabs/cosmos-tax-cli/osmosis/modules/poolmanager"
+	"github.com/DefiantLabs/cosmos-tax-cli/osmosis/modules/tokenfactory"
 	"github.com/DefiantLabs/cosmos-tax-cli/osmosis/modules/valsetpref"
 	"github.com/DefiantLabs/cosmos-tax-cli/util"
 )
@@ -219,6 +220,8 @@ func ParseTx(address string, events []db.TaxableTransaction) (rows []parsers.Csv
 			newRow, err = ParseConcentratedLiquidityCollection(event)
 		case valsetpref.MsgDelegateBondedTokens, valsetpref.MsgUndelegateFromValidatorSet, valsetpref.MsgRedelegateValidatorSet, valsetpref.MsgWithdrawDelegationRewards, valsetpref.MsgDelegateToValidatorSet, valsetpref.MsgUndelegateFromRebalancedValidatorSet:
 			newRow, err = ParseValsetPrefRewards(event)
+		case tokenfactory.MsgMint, tokenfactory.MsgBurn:
+			newRow, err = ParseTokenFactoryEvents(address, event)
 		default:
 			config.Log.Errorf("no parser for message type '%v'", event.Message.MessageType.MessageType)
 			continue
@@ -438,6 +441,16 @@ func ParseValsetPrefRewards(event db.TaxableTransaction) (Row, error) {
 	err := parseAndAddReceivedAmount(row, event)
 	if err != nil {
 		return *row, err
+	}
+
+	return *row, nil
+}
+
+func ParseTokenFactoryEvents(address string, event db.TaxableTransaction) (Row, error) {
+	row := &Row{}
+	err := row.ParseBasic(address, event)
+	if err != nil {
+		config.Log.Error("Error with ParseMsgMultiSend.", err)
 	}
 
 	return *row, nil

--- a/csv/parsers/koinly/koinly.go
+++ b/csv/parsers/koinly/koinly.go
@@ -18,6 +18,7 @@ import (
 	"github.com/DefiantLabs/cosmos-tax-cli/osmosis/modules/concentratedliquidity"
 	"github.com/DefiantLabs/cosmos-tax-cli/osmosis/modules/gamm"
 	"github.com/DefiantLabs/cosmos-tax-cli/osmosis/modules/poolmanager"
+	"github.com/DefiantLabs/cosmos-tax-cli/osmosis/modules/tokenfactory"
 	"github.com/DefiantLabs/cosmos-tax-cli/osmosis/modules/valsetpref"
 	"github.com/DefiantLabs/cosmos-tax-cli/util"
 )
@@ -322,6 +323,8 @@ func ParseTx(address string, events []db.TaxableTransaction) (rows []parsers.Csv
 			newRow, err = ParseConcentratedLiquidityCollection(event)
 		case valsetpref.MsgDelegateBondedTokens, valsetpref.MsgUndelegateFromValidatorSet, valsetpref.MsgRedelegateValidatorSet, valsetpref.MsgWithdrawDelegationRewards, valsetpref.MsgDelegateToValidatorSet, valsetpref.MsgUndelegateFromRebalancedValidatorSet:
 			newRow, err = ParseValsetPrefRewards(event)
+		case tokenfactory.MsgMint, tokenfactory.MsgBurn:
+			newRow, err = ParseTokenFactoryEvents(address, event)
 		default:
 			config.Log.Errorf("no parser for message type '%v'", event.Message.MessageType.MessageType)
 			continue
@@ -539,6 +542,16 @@ func ParseValsetPrefRewards(event db.TaxableTransaction) (Row, error) {
 	err := parseAndAddReceivedAmount(row, event)
 	if err != nil {
 		return *row, err
+	}
+
+	return *row, nil
+}
+
+func ParseTokenFactoryEvents(address string, event db.TaxableTransaction) (Row, error) {
+	row := &Row{}
+	err := row.ParseBasic(address, event)
+	if err != nil {
+		config.Log.Error("Error with ParseMsgMultiSend.", err)
 	}
 
 	return *row, nil

--- a/csv/parsers/koinly/koinly.go
+++ b/csv/parsers/koinly/koinly.go
@@ -18,6 +18,7 @@ import (
 	"github.com/DefiantLabs/cosmos-tax-cli/osmosis/modules/concentratedliquidity"
 	"github.com/DefiantLabs/cosmos-tax-cli/osmosis/modules/gamm"
 	"github.com/DefiantLabs/cosmos-tax-cli/osmosis/modules/poolmanager"
+	"github.com/DefiantLabs/cosmos-tax-cli/osmosis/modules/valsetpref"
 	"github.com/DefiantLabs/cosmos-tax-cli/util"
 )
 
@@ -319,6 +320,8 @@ func ParseTx(address string, events []db.TaxableTransaction) (rows []parsers.Csv
 			newRow, err = ParsePoolManagerSwap(event)
 		case concentratedliquidity.MsgCollectIncentives, concentratedliquidity.MsgCollectSpreadRewards:
 			newRow, err = ParseConcentratedLiquidityCollection(event)
+		case valsetpref.MsgDelegateBondedTokens, valsetpref.MsgUndelegateFromValidatorSet, valsetpref.MsgRedelegateValidatorSet, valsetpref.MsgWithdrawDelegationRewards, valsetpref.MsgDelegateToValidatorSet, valsetpref.MsgUndelegateFromRebalancedValidatorSet:
+			newRow, err = ParseValsetPrefRewards(event)
 		default:
 			config.Log.Errorf("no parser for message type '%v'", event.Message.MessageType.MessageType)
 			continue
@@ -525,4 +528,18 @@ func ParseConcentratedLiquidityCollection(event db.TaxableTransaction) (Row, err
 	row.TxHash = event.Message.Tx.Hash
 
 	return *row, err
+}
+
+func ParseValsetPrefRewards(event db.TaxableTransaction) (Row, error) {
+	row := &Row{}
+	row.Label = Income
+	row.Date = event.Message.Tx.Block.TimeStamp.Format(TimeLayout)
+	row.TxHash = event.Message.Tx.Hash
+
+	err := parseAndAddReceivedAmount(row, event)
+	if err != nil {
+		return *row, err
+	}
+
+	return *row, nil
 }

--- a/csv/parsers/taxbit/taxbit.go
+++ b/csv/parsers/taxbit/taxbit.go
@@ -14,6 +14,7 @@ import (
 	"github.com/DefiantLabs/cosmos-tax-cli/db"
 	"github.com/DefiantLabs/cosmos-tax-cli/osmosis/modules/gamm"
 	"github.com/DefiantLabs/cosmos-tax-cli/osmosis/modules/poolmanager"
+	"github.com/DefiantLabs/cosmos-tax-cli/osmosis/modules/tokenfactory"
 	"github.com/DefiantLabs/cosmos-tax-cli/osmosis/modules/valsetpref"
 )
 
@@ -249,6 +250,8 @@ func ParseTx(address string, events []db.TaxableTransaction) (rows []parsers.Csv
 			newRow, err = ParsePoolManagerSwap(event)
 		case valsetpref.MsgDelegateBondedTokens, valsetpref.MsgUndelegateFromValidatorSet, valsetpref.MsgRedelegateValidatorSet, valsetpref.MsgWithdrawDelegationRewards, valsetpref.MsgDelegateToValidatorSet, valsetpref.MsgUndelegateFromRebalancedValidatorSet:
 			newRow, err = ParseValsetPrefRewards(event)
+		case tokenfactory.MsgMint, tokenfactory.MsgBurn:
+			newRow, err = ParseTokenFactoryEvents(address, event)
 		default:
 			config.Log.Errorf("no parser for message type '%v'", event.Message.MessageType.MessageType)
 			continue
@@ -390,6 +393,16 @@ func ParseValsetPrefRewards(event db.TaxableTransaction) (Row, error) {
 	err := parseAndAddReceivedAmount(row, event)
 	if err != nil {
 		return *row, err
+	}
+
+	return *row, nil
+}
+
+func ParseTokenFactoryEvents(address string, event db.TaxableTransaction) (Row, error) {
+	row := &Row{}
+	err := row.ParseBasic(address, event)
+	if err != nil {
+		config.Log.Error("Error with ParseMsgMultiSend.", err)
 	}
 
 	return *row, nil


### PR DESCRIPTION
Adds csv parsers for:

1. Entire line of valsetpref  reward withdrawal events
2. Tokenfactory MsgMint and MsgBurn